### PR TITLE
feat: 添加开机自启动和启动时最小化到托盘功能

### DIFF
--- a/src/main/storage/settings.ts
+++ b/src/main/storage/settings.ts
@@ -19,6 +19,7 @@ export type MainAppSettings = {
   rememberWindowSize: boolean;
   preventSleep: boolean;
   disableGpuAcceleration: boolean;
+  startMinimized: boolean;
   windowState: MainWindowState;
 };
 
@@ -39,6 +40,7 @@ export const DEFAULT_MAIN_APP_SETTINGS: MainAppSettings = {
   rememberWindowSize: true,
   preventSleep: true,
   disableGpuAcceleration: false,
+  startMinimized: false,
   windowState: {
     width: 1100,
     height: 750,

--- a/src/main/storage/settings.ts
+++ b/src/main/storage/settings.ts
@@ -19,6 +19,7 @@ export type MainAppSettings = {
   rememberWindowSize: boolean;
   preventSleep: boolean;
   disableGpuAcceleration: boolean;
+  autoLaunch: boolean;
   startMinimized: boolean;
   windowState: MainWindowState;
 };
@@ -40,6 +41,7 @@ export const DEFAULT_MAIN_APP_SETTINGS: MainAppSettings = {
   rememberWindowSize: true,
   preventSleep: true,
   disableGpuAcceleration: false,
+  autoLaunch: false,
   startMinimized: false,
   windowState: {
     width: 1100,

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -114,6 +114,10 @@ ipcMain.on('update-remember-window-size', (_event, enabled: boolean) => {
   setMainAppSetting('rememberWindowSize', enabled);
 });
 
+ipcMain.on('update-start-minimized', (_event, enabled: boolean) => {
+  setMainAppSetting('startMinimized', enabled);
+});
+
 const syncPowerSaveBlocker = () => {
   const shouldBlock = preventSleep && isPlaybackActive && !systemSuspended;
   if (shouldBlock) {
@@ -263,8 +267,11 @@ export async function createWindow() {
   }
 
   // 当窗口准备好显示时再展示，优雅解决启动白屏
+  // 如果启用了启动时最小化，则不自动显示窗口，由用户通过托盘恢复
   win.once('ready-to-show', () => {
-    win?.show();
+    if (!initialSettings.startMinimized) {
+      win?.show();
+    }
   });
 
   // 禁止视觉缩放 + 强制 zoomFactor，兜底防止 Windows 高 DPI 下意外缩放。

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -29,6 +29,9 @@ let isPlaybackActive = false;
 let systemSuspended = false;
 let powerSaveBlockerId = -1;
 
+// 启动时同步开机自启动状态，确保注册表与设置一致
+app.setLoginItemSettings({ openAtLogin: initialSettings.autoLaunch });
+
 let win: BrowserWindow | null = null;
 let isQuitting = false;
 
@@ -116,6 +119,11 @@ ipcMain.on('update-remember-window-size', (_event, enabled: boolean) => {
 
 ipcMain.on('update-start-minimized', (_event, enabled: boolean) => {
   setMainAppSetting('startMinimized', enabled);
+});
+
+ipcMain.on('update-auto-launch', (_event, enabled: boolean) => {
+  setMainAppSetting('autoLaunch', enabled);
+  app.setLoginItemSettings({ openAtLogin: enabled });
 });
 
 const syncPowerSaveBlocker = () => {

--- a/src/renderer/stores/setting.ts
+++ b/src/renderer/stores/setting.ts
@@ -132,6 +132,7 @@ export const useSettingStore = defineStore('setting', {
     searchHistory: [] as string[],
     userAgreementAccepted: false,
     disableGpuAcceleration: false,
+    autoLaunch: false,
     startMinimized: false,
     logLevel: 'info' as AppLogLevel,
     logApiResponseBody: false,
@@ -233,6 +234,11 @@ export const useSettingStore = defineStore('setting', {
           'update-disable-gpu-acceleration',
           this.disableGpuAcceleration,
         );
+      }
+    },
+    syncAutoLaunch() {
+      if (window.electron?.ipcRenderer) {
+        window.electron.ipcRenderer.send('update-auto-launch', this.autoLaunch);
       }
     },
     syncStartMinimized() {

--- a/src/renderer/stores/setting.ts
+++ b/src/renderer/stores/setting.ts
@@ -132,6 +132,7 @@ export const useSettingStore = defineStore('setting', {
     searchHistory: [] as string[],
     userAgreementAccepted: false,
     disableGpuAcceleration: false,
+    startMinimized: false,
     logLevel: 'info' as AppLogLevel,
     logApiResponseBody: false,
     logDiagnosticUntil: 0,
@@ -232,6 +233,11 @@ export const useSettingStore = defineStore('setting', {
           'update-disable-gpu-acceleration',
           this.disableGpuAcceleration,
         );
+      }
+    },
+    syncStartMinimized() {
+      if (window.electron?.ipcRenderer) {
+        window.electron.ipcRenderer.send('update-start-minimized', this.startMinimized);
       }
     },
     getLogSettings(): LogSettings {

--- a/src/renderer/views/settings/components/AppearanceSettingsSection.vue
+++ b/src/renderer/views/settings/components/AppearanceSettingsSection.vue
@@ -160,8 +160,19 @@ const resolvedTitle = computed(() => title.label);
     <div class="settings-divider"></div>
     <div class="settings-item">
       <div class="space-y-1">
+        <h3 class="font-semibold">开机自启动</h3>
+        <p class="text-sm text-text-secondary">登录系统时自动启动应用</p>
+      </div>
+      <Switch
+        v-model="settingStore.autoLaunch"
+        @update:model-value="settingStore.syncAutoLaunch()"
+      />
+    </div>
+    <div class="settings-divider"></div>
+    <div class="settings-item">
+      <div class="space-y-1">
         <h3 class="font-semibold">启动时最小化到托盘</h3>
-        <p class="text-sm text-text-secondary">开机自启时不显示主窗口，直接最小化到系统托盘</p>
+        <p class="text-sm text-text-secondary">启动后不显示主窗口，直接最小化到系统托盘</p>
       </div>
       <Switch
         v-model="settingStore.startMinimized"

--- a/src/renderer/views/settings/components/AppearanceSettingsSection.vue
+++ b/src/renderer/views/settings/components/AppearanceSettingsSection.vue
@@ -157,6 +157,17 @@ const resolvedTitle = computed(() => title.label);
         "
       />
     </div>
+    <div class="settings-divider"></div>
+    <div class="settings-item">
+      <div class="space-y-1">
+        <h3 class="font-semibold">启动时最小化到托盘</h3>
+        <p class="text-sm text-text-secondary">开机自启时不显示主窗口，直接最小化到系统托盘</p>
+      </div>
+      <Switch
+        v-model="settingStore.startMinimized"
+        @update:model-value="settingStore.syncStartMinimized()"
+      />
+    </div>
 
     <ColorPickerDialog
       :open="showAccentPicker"


### PR DESCRIPTION
概述
- 新增「开机自启动」开关，使用 Electron 的 app.setLoginItemSettings() 注册/取消系统登录时自动启动
- 新增「启动时最小化到托盘」开关，启动后不显示主窗口，直接最小化到系统托盘
- 两个选项位于设置页面的「外观」区域，与现有的「关闭行为」设置归为一组
改动说明
1. `src/main/storage/settings.ts` — 在 MainAppSettings 中添加 `autoLaunch` 和 `startMinimized` 字段及默认值
2. `src/main/window.ts` — 启动时同步开机自启动注册表状态；`ready-to-show` 时根据设置决定是否显示窗口；添加对应的 IPC 处理
3. `src/renderer/stores/setting.ts` — 在 Pinia store 中添加状态和同步方法
4. `src/renderer/views/settings/components/AppearanceSettingsSection.vue` — 添加两个 Switch 开关
测试计划
- [ ] 开启「开机自启动」→ 检查 Windows 注册表中出现 EchoMusic 启动项
- [ ] 关闭「开机自启动」→ 注册表启动项被移除
- [ ] 开启「启动时最小化到托盘」→ 重启应用 → 窗口不显示，托盘图标出现
- [ ] 点击托盘图标 → 窗口正常恢复
- [ ] 两项设置在重启应用后保持不变