### PR TITLE
feat: 添加桌面歌词状态角标显示设置项

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dist
 dist-electron
 out
 release
+build/mpv/
 *.dmg
 *.exe
 *.deb

--- a/src/renderer/layouts/PlayerBar.vue
+++ b/src/renderer/layouts/PlayerBar.vue
@@ -536,6 +536,7 @@ onUnmounted(() => {
             <Icon :icon="iconTypography" width="20" height="20" />
           </Button>
           <Badge
+            v-if="settingStore.showDesktopLyricStatus"
             :count="desktopLyricStore.settings.enabled ? 'ON' : 'OFF'"
             class="-top-px"
             style="right: -5px"

--- a/src/renderer/stores/setting.ts
+++ b/src/renderer/stores/setting.ts
@@ -114,6 +114,7 @@ export const useSettingStore = defineStore('setting', {
     outputDeviceDisconnectBehavior: 'pause' as OutputDeviceDisconnectBehavior,
     autoReceiveVip: false,
     showAudioQualityBadge: true,
+    showDesktopLyricStatus: true,
     volumeNormalization: true,
     volumeNormalizationLufs: -14,
     impulseResponseEnabled: false,

--- a/src/renderer/views/lyric/LyricPlayerControls.vue
+++ b/src/renderer/views/lyric/LyricPlayerControls.vue
@@ -341,6 +341,7 @@ const handleCopySongInfo = async () => {
             <Icon :icon="iconTypography" width="20" height="20" />
           </Button>
           <Badge
+            v-if="settingStore.showDesktopLyricStatus"
             :count="desktopLyricStore.settings.enabled ? 'ON' : 'OFF'"
             class="-top-px"
             style="right: -5px"

--- a/src/renderer/views/settings/components/AppearanceSettingsSection.vue
+++ b/src/renderer/views/settings/components/AppearanceSettingsSection.vue
@@ -120,6 +120,14 @@ const resolvedTitle = computed(() => title.label);
     <div class="settings-divider"></div>
     <div class="settings-item">
       <div class="space-y-1">
+        <h3 class="font-semibold">桌面歌词状态</h3>
+        <p class="text-sm text-text-secondary">在播放器桌面歌词图标上显示开启或关闭状态角标</p>
+      </div>
+      <Switch v-model="settingStore.showDesktopLyricStatus" />
+    </div>
+    <div class="settings-divider"></div>
+    <div class="settings-item">
+      <div class="space-y-1">
         <h3 class="font-semibold">播放列表计数</h3>
         <p class="text-sm text-text-secondary">在播放器播放列表图标上显示计数</p>
       </div>


### PR DESCRIPTION
新增桌面歌词状态设置项，位于**设置 > 外观**中音质音效徽标与播放列表计数之间。

## 修改内容
- 新增 showDesktopLyricStatus 状态（默认开启）
- PlayerBar / LyricPlayerControls 中桌面歌词 Badge 添加 v-if 控制显隐
- 将 build/mpv/ 加入 .gitignore

## 行为
- 开启（默认）：桌面歌词图标上显示 ON/OFF 状态角标  
- 关闭：隐藏角标，不影响桌面歌词功能