### PR TITLE
fix(linuxEnv): 修复 libav 库版本号匹配正则导致 HTTP 音频流无法播放

### DIFF
--- a/src/main/mpv/linuxEnv.ts
+++ b/src/main/mpv/linuxEnv.ts
@@ -72,8 +72,8 @@ function findVersionedLib(dir: string, dirEntries: string[], pattern: string): s
     .filter((e) => {
       if (!e.startsWith(baseName)) return false;
       const suffix = e.slice(baseName.length);
-      // 必须是数字开头的版本后缀（如 '60' 或 '60.3.100'）
-      return /^\d+/.test(suffix);
+      // 版本后缀可能以点号开头，如 libavformat.so.62 → '.62'
+      return /^\.?\d+/.test(suffix);
     })
     .sort((a, b) => a.length - b.length);
 


### PR DESCRIPTION
Linux 上播放 HTTP 音频流时，mpv 报 Protocol not found。

  原因是 findVersionedLib() 中的正则 /^\d+/ 无法匹配以点号开头的版本后缀（如 libavformat.so.62 → '.62'），导致 LD_PRELOAD修复机制从未生效，Electron 捆绑的残缺 libffmpeg.so 始终优先加载，其缺失的 HTTP/TCP 协议实现引发了该错误。
正则为 /^\.?\d+/ 即可同时兼容 '.62' 和 '62.3.100' 两种后缀格式。

  **Reproduction:**
  - 系统：Arch Linux, Electron 42, FFmpeg 8.1
  - 错误日志：
    [mpv/audio] Could not open audio: Protocol not found
  - 直接原因验证：手动 `LD_PRELOAD=/usr/lib/libavformat.so.62`
  后播放正常
  - 关联 Issue：#158
  
  *由AI完成分析修复，本人不熟悉代码，不过提交前已在实际系统上验证通过。*