### PR TITLE
fix: restore thumbar buttons after hiding to tray

### DIFF
--- a/src/main/thumbar.ts
+++ b/src/main/thumbar.ts
@@ -302,6 +302,13 @@ export function setupThumbarButtons(win: BrowserWindow) {
         applyThumbarButtons(win);
       }
     });
+
+    // 窗口从隐藏恢复时重新设置 thumbar 按钮（setSkipTaskbar 会清除按钮）
+    win.on('show', () => {
+      if (!win.isDestroyed()) {
+        applyThumbarButtons(win);
+      }
+    });
   }
 
   applyThumbarButtons(win);


### PR DESCRIPTION
## Summary
- Fix thumbar buttons disappearing after hiding window to tray and showing again
- `setSkipTaskbar` clears thumbar buttons; re-apply on window `show` event

## Changes
- **`src/main/thumbar.ts`**: Add `win.on('show')` listener to re-apply thumbar buttons when window is restored
