### PR TITLE
fix: restore thumbar buttons after SMTC media control usage when hidden to tray

### DIFF
--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -74,11 +74,12 @@ export function showMainWindow() {
     win.restore();
   }
 
-  win.setSkipTaskbar(false);
-
+  // 先 show 再 setSkipTaskbar(false)，确保窗口可见后任务栏条目能正确创建
   if (!wasVisible) {
     win.show();
   }
+
+  win.setSkipTaskbar(false);
 
   if (!wasVisible || wasMinimized || !wasFocused) {
     win.moveTop();


### PR DESCRIPTION
## Summary
- Fix thumbar buttons (prev/play/next) disappearing from taskbar after using Windows media controls (SMTC) while the app was hidden to tray

## Problem
When the app was hidden to tray and the user controlled playback via Windows media keys (SMTC), restoring the window would show the taskbar without the thumbar control buttons.

## Root Cause
In showMainWindow, win.setSkipTaskbar(false) was called before win.show(). This caused Windows to recreate the taskbar entry while the window was still hidden, preventing thumbar buttons from being properly restored.

## Fix
Swap the call order: call win.show() first to make the window visible, then win.setSkipTaskbar(false) to add it back to the taskbar. This ensures the taskbar entry is created with the window in a visible state, allowing thumbar buttons to be set correctly.