### PR TITLE
fix: lyric effect snapshot index jitter filter

### DIFF
--- a/src/renderer/views/lyric/LyricScroller.vue
+++ b/src/renderer/views/lyric/LyricScroller.vue
@@ -181,15 +181,36 @@ const lyricEffectSummary = computed(() => getPluginLyricEffectSummary('page'));
 const getLineStartMs = (line: (typeof lyricStore.lines)[number]) =>
   line.characters?.[0]?.startTime ?? Math.round((Number(line.time) || 0) * 1000);
 
+let lastStableLyricIndex = -1;
+let lastStableLyricTime = 0;
+
 const buildLyricEffectSnapshot = (): PluginLyricEffectSnapshot => {
-  const index = currentIndex.value;
+  let index = currentIndex.value;
+  const time = playerStore.currentTime;
+
+  // Filter out playback jitter: if the index jumped backward by <= 2 lines
+  // and time hasn't regressed significantly, keep the previous stable index.
+  // This prevents the lyric effect from briefly highlighting the wrong line.
+  if (
+    lastStableLyricIndex >= 0 &&
+    index >= 0 &&
+    index < lastStableLyricIndex &&
+    lastStableLyricIndex - index <= 2 &&
+    time >= lastStableLyricTime - 0.35
+  ) {
+    index = lastStableLyricIndex;
+  } else {
+    lastStableLyricIndex = index;
+  }
+  lastStableLyricTime = time;
+
   return {
     scope: 'page',
     lines: lyricStore.lines,
     currentIndex: index,
     scrollIndex: scrollIndex.value,
     currentLine: index >= 0 ? (lyricStore.lines[index] ?? null) : null,
-    currentTime: playerStore.currentTime,
+    currentTime: time,
     duration: playerStore.duration,
     playbackRate: playerStore.playbackRate,
     isPlaying: playerStore.isPlaying,


### PR DESCRIPTION
## Summary
- `buildLyricEffectSnapshot` 中加入 index 稳定化逻辑，与 miniPlayer 的 `stabilizeLyricPayload` 一致
- 当 `currentIndex` 向后抖动 <= 2 行且时间未明显回退时，保持上一个稳定值
- 防止歌词特效（如旧版虾米风格、Apple Music 弹跳等）在换行时短暂高亮错误行

## Test
在歌词页面启用旧版虾米歌词风格插件，播放带歌词的歌曲，观察换行时效果是否还有闪回。
