### PR TITLE
fix: context menu separator inconsistent thickness

### DIFF
--- a/src/renderer/components/music/SongCard.vue
+++ b/src/renderer/components/music/SongCard.vue
@@ -610,9 +610,9 @@ const handleFavorite = () => {
 }
 
 :deep(.song-context-separator) {
-  height: 1px;
+  border: none;
+  border-top: 1px solid var(--border-subtle);
   margin: 4px 6px;
-  background-color: var(--border-subtle);
 }
 
 .song-title-row {

--- a/src/renderer/components/music/SongList.vue
+++ b/src/renderer/components/music/SongList.vue
@@ -1083,8 +1083,8 @@ defineExpose({ scrollToActive, filteredCount: computed(() => filteredSongsRef.va
 }
 
 :global(.song-context-separator) {
-  height: 1px;
+  border: none;
+  border-top: 1px solid var(--border-subtle);
   margin: 4px 6px;
-  background-color: var(--border-subtle);
 }
 </style>


### PR DESCRIPTION
## Summary

- Replace \height\ + \ackground-color\ with \order-top\ for song context menu separators in \SongList.vue\ and \SongCard.vue\
- This ensures consistent 1px rendering across all separator instances regardless of flex container positioning

## Problem

The right-click context menu on songs had two separator lines with visibly different thickness. Both used the same CSS class but the different HTML formatting (single-line vs multi-line) caused inconsistent rendering in the flex layout.

## Solution

Using \order-top\ instead of \height\ + \ackground-color\ eliminates content/whitespace text node interference and provides a reliable 1px line rendering.