### PR TITLE
fix: sidebar rail tooltip z-index and add missing tooltip

### DIFF
--- a/src/renderer/components/ui/Tooltip.vue
+++ b/src/renderer/components/ui/Tooltip.vue
@@ -67,7 +67,7 @@ const props = withDefaults(defineProps<Props>(), {
   font-weight: 600;
   line-height: 1.45;
   box-shadow: var(--shadow-elevated);
-  z-index: 300;
+  z-index: 2000;
   user-select: none;
 }
 

--- a/src/renderer/layouts/Sidebar.vue
+++ b/src/renderer/layouts/Sidebar.vue
@@ -847,15 +847,19 @@ watch(
             content-class="sidebar-rail-more-menu"
           >
             <template #trigger>
-              <Button
-                variant="unstyled"
-                size="none"
-                type="button"
-                class="sidebar-rail-item"
-                title="歌单操作"
-              >
-                <Icon :icon="iconDotsVertical" width="18" height="18" />
-              </Button>
+              <Tooltip content="歌单操作" side="right">
+                <template #trigger>
+                  <Button
+                    variant="unstyled"
+                    size="none"
+                    type="button"
+                    class="sidebar-rail-item"
+                    title="歌单操作"
+                  >
+                    <Icon :icon="iconDotsVertical" width="18" height="18" />
+                  </Button>
+                </template>
+              </Tooltip>
             </template>
             <div class="sidebar-rail-more-list">
               <div class="sidebar-sort-menu-title">歌单操作</div>


### PR DESCRIPTION
## Summary
- 提高Tooltip z-index从300到2000，防止播放控制栏遮挡提示窗
- 为收起状态下侧边栏的歌单操作按钮添加缺失的Tooltip提示