### PR TITLE
fix: add missing Win32_System_Com_StructuredStorage feature

### DIFF
--- a/native/echo-ffmpeg-player/Cargo.toml
+++ b/native/echo-ffmpeg-player/Cargo.toml
@@ -27,6 +27,7 @@ windows = { version = "0.58", features = [
   "Win32_Media_Multimedia",
   "Win32_Security",
   "Win32_System_Com",
+  "Win32_System_Com_StructuredStorage",
   "Win32_System_Threading",
   "Win32_System_Variant",
   "Win32_UI_Shell_PropertiesSystem"


### PR DESCRIPTION
Fixes compilation error on Windows with windows crate v0.58.

The StructuredStorage module is gated behind the Win32_System_Com_StructuredStorage feature flag, which is required by platform_windows.rs but was missing from Cargo.toml.