### PR TITLE
fix: add missing Win32_System_Com_StructuredStorage feature

### DIFF
--- a/native/echo-ffmpeg-player/Cargo.toml
+++ b/native/echo-ffmpeg-player/Cargo.toml
@@ -27,6 +27,7 @@ windows = { version = "0.58", features = [
   "Win32_Media_Multimedia",
   "Win32_Security",
   "Win32_System_Com",
+  "Win32_System_Com_StructuredStorage",
   "Win32_System_Threading",
   "Win32_System_Variant",
   "Win32_UI_Shell_PropertiesSystem"


### PR DESCRIPTION
## Problem

Building `native/echo-ffmpeg-player` fails on `windows` crate v0.58 with:

```
error[E0432]: unresolved import `windows::Win32::System::Com::StructuredStorage`
```

`platform_windows.rs` imports `StructuredStorage` from `Win32::System::Com`, but this module is gated behind the `Win32_System_Com_StructuredStorage` feature flag which is missing from `Cargo.toml`.

## Fix

Add `"Win32_System_Com_StructuredStorage"` to the `windows` features list in `native/echo-ffmpeg-player/Cargo.toml`.

## Verified

- `napi build --release` succeeds
- `pnpm dev` launches and plays audio correctly
