### PR TITLE
feat: 任务栏封面预览开关、无边框缩略图与切歌黑窗修复

### DIFF
--- a/native/echo-media-controls/src/taskbar.rs
+++ b/native/echo-media-controls/src/taskbar.rs
@@ -9,6 +9,7 @@
 //! 窗口消息的钩子在主进程（Electron `hookWindowMessage`）中完成，本模块只负责
 //! 「构建位图 + 调用 DWM API」，与 SMTC 逻辑完全解耦。
 
+use image::GenericImageView;
 use napi::bindgen_prelude::Buffer;
 use napi_derive::napi;
 
@@ -20,9 +21,6 @@ use windows::Win32::Graphics::Dwm::{
 use windows::Win32::Graphics::Gdi::{
     CreateDIBSection, DeleteObject, BITMAPINFO, BITMAPINFOHEADER, DIB_RGB_COLORS, HBITMAP, HGDIOBJ,
 };
-
-/// DwmSetIconicThumbnail / LivePreview 的标志：绘制带边框的窗口帧
-const DWM_SIT_DISPLAYFRAME: u32 = 0x0000_0001;
 
 /// 将 JS 传入的窗口句柄字符串（无符号十进制指针值）解析为 HWND
 fn parse_hwnd(hwnd: &str) -> Option<HWND> {
@@ -67,16 +65,27 @@ unsafe fn create_dib(width: i32, height: i32) -> Result<(HBITMAP, *mut u8), Stri
     Ok((hbmp, bits as *mut u8))
 }
 
-/// 解码图片并等比缩放到 `max_w x max_h` 框内，返回 RGBA 像素与实际尺寸。
+/// 解码图片并等比缩放（保持原始纵横比）后居中放到 `max_w x max_h` 的透明画布上，
+/// 返回 RGBA 像素与实际尺寸（始终为 `max_w x max_h`）。
 fn decode_scaled(data: &[u8], max_w: u32, max_h: u32) -> Result<(Vec<u8>, u32, u32), String> {
     let img = image::load_from_memory(data).map_err(|e| format!("decode image failed: {e}"))?;
     let max_w = max_w.max(1);
     let max_h = max_h.max(1);
-    // resize 等比缩放使图片完整落入框内
-    let scaled = img.resize(max_w, max_h, image::imageops::FilterType::Lanczos3);
-    let rgba = scaled.to_rgba8();
-    let (w, h) = rgba.dimensions();
-    Ok((rgba.into_raw(), w, h))
+    let (src_w, src_h) = img.dimensions();
+    let src_w = src_w.max(1);
+    let src_h = src_h.max(1);
+    // 计算等比缩放到框内（不超出边界）的目标尺寸，避免方形封面被横向拉伸
+    let scale = (max_w as f64 / src_w as f64).min(max_h as f64 / src_h as f64);
+    let out_w = (src_w as f64 * scale).max(1.0).round() as u32;
+    let out_h = (src_h as f64 * scale).max(1.0).round() as u32;
+    // 此时 scale 不改变纵横比，不会产生形变
+    let scaled = img.resize(out_w, out_h, image::imageops::FilterType::Lanczos3);
+    // 建透明画布并居中粘贴，四周留边透明，位图尺寸与 DWM 请求的矩形一致
+    let mut canvas = image::RgbaImage::from_pixel(max_w, max_h, image::Rgba([0, 0, 0, 0]));
+    let ox = (max_w - out_w) / 2;
+    let oy = (max_h - out_h) / 2;
+    image::imageops::overlay(&mut canvas, &scaled, ox as i64, oy as i64);
+    Ok((canvas.into_raw(), max_w, max_h))
 }
 
 /// 将 RGBA 像素写入 DIB（GDI 需要 BGRA 排列）。
@@ -150,7 +159,7 @@ pub fn taskbar_set_thumbnail(
 ) -> napi::Result<()> {
     let hwnd = parse_hwnd(&hwnd).ok_or_else(|| napi::Error::from_reason("invalid hwnd"))?;
     render_and_apply(hwnd, image.as_ref(), max_width, max_height, |hwnd, hbmp| unsafe {
-        DwmSetIconicThumbnail(hwnd, hbmp, DWM_SIT_DISPLAYFRAME)
+        DwmSetIconicThumbnail(hwnd, hbmp, 0)
             .map_err(|e| format!("DwmSetIconicThumbnail failed: {e}"))
     })
     .map_err(napi::Error::from_reason)
@@ -166,7 +175,7 @@ pub fn taskbar_set_live_preview(
 ) -> napi::Result<()> {
     let hwnd = parse_hwnd(&hwnd).ok_or_else(|| napi::Error::from_reason("invalid hwnd"))?;
     render_and_apply(hwnd, image.as_ref(), max_width, max_height, |hwnd, hbmp| unsafe {
-        DwmSetIconicLivePreviewBitmap(hwnd, hbmp, None, DWM_SIT_DISPLAYFRAME)
+        DwmSetIconicLivePreviewBitmap(hwnd, hbmp, None, 0)
             .map_err(|e| format!("DwmSetIconicLivePreviewBitmap failed: {e}"))
     })
     .map_err(napi::Error::from_reason)

--- a/src/main/mediaControls.ts
+++ b/src/main/mediaControls.ts
@@ -35,8 +35,24 @@ let coverAbortController: AbortController | null = null;
 let metadataUpdateSeq = 0;
 let lastCoverCache: { url: string; data: Buffer | null } | null = null;
 let activeCoverDownload: { url: string; promise: Promise<Buffer | null> } | null = null;
+let fallbackCoverCache: { url: string; data: Buffer | null } | null = null;
 const nativeRequire = createRequire(path.join(process.cwd(), 'package.json'));
 const METADATA_COVER_SETTLE_MS = 120;
+
+// 与渲染端 DEFAULT_COVER_URL 保持一致的应用兜底封面。
+// 当后台任务窗口确实无法得到可用封面时，用它代替 DWM 回退到实时窗口捕获（黑屏）。
+const FALLBACK_COVER_URL = 'https://imge.kugou.com/soft/collection/default.jpg';
+
+/** 加载并缓存应用的兜底封面（只下载一次）。 */
+function ensureFallbackCover(): Promise<Buffer | null> {
+  if (fallbackCoverCache) return Promise.resolve(fallbackCoverCache.data);
+  return resolveCoverImage(FALLBACK_COVER_URL).then((data) => {
+    if (!fallbackCoverCache) {
+      fallbackCoverCache = { url: FALLBACK_COVER_URL, data };
+    }
+    return fallbackCoverCache.data;
+  });
+}
 
 const isAbortError = (error: unknown) =>
   error instanceof Error && (error.name === 'AbortError' || error.message === 'AbortError');
@@ -162,6 +178,10 @@ async function resolveCoverImage(url: string, signal?: AbortSignal): Promise<Buf
 /** 初始化原生媒体控制服务 */
 export function initMediaControls(getMainWindow: () => BrowserWindow | null): void {
   nativeModule = loadNativeModule();
+
+  // 预热兜底封面，保证在真实封面缺失/失败时能立刻回退，避免任务栏黑窗
+  void ensureFallbackCover();
+
   if (!nativeModule) {
     log.warn('[MediaControls] Native addon unavailable, using fallback');
     registerFallbackIpc();
@@ -244,7 +264,15 @@ export function initMediaControls(getMainWindow: () => BrowserWindow | null): vo
       }
 
       // 任务栏 DWM 缩略图需要及时响应系统请求，不能被 SMTC 的异步元数据更新挡住。
-      setTaskbarCover(coverData);
+      // 仅在有可用封面时才更新为真实封面；切歌瞬间若新封面尚未就绪，
+      // 保留上一张封面，避免 DWM 回退到实时窗口捕获而显示黑窗。
+      if (coverData) {
+        setTaskbarCover(coverData);
+      } else {
+        // 当前歌曲确实拿不到封面时，用应用的兜底封面兜底，同样避免黑窗。
+        const fallback = await ensureFallbackCover();
+        if (fallback) setTaskbarCover(fallback);
+      }
 
       try {
         // native addon 期望 coverData 为 number[]（NAPI-RS 的 Vec<u8> 映射）

--- a/src/main/mediaControls.ts
+++ b/src/main/mediaControls.ts
@@ -35,24 +35,8 @@ let coverAbortController: AbortController | null = null;
 let metadataUpdateSeq = 0;
 let lastCoverCache: { url: string; data: Buffer | null } | null = null;
 let activeCoverDownload: { url: string; promise: Promise<Buffer | null> } | null = null;
-let fallbackCoverCache: { url: string; data: Buffer | null } | null = null;
 const nativeRequire = createRequire(path.join(process.cwd(), 'package.json'));
 const METADATA_COVER_SETTLE_MS = 120;
-
-// 与渲染端 DEFAULT_COVER_URL 保持一致的应用兜底封面。
-// 当后台任务窗口确实无法得到可用封面时，用它代替 DWM 回退到实时窗口捕获（黑屏）。
-const FALLBACK_COVER_URL = 'https://imge.kugou.com/soft/collection/default.jpg';
-
-/** 加载并缓存应用的兜底封面（只下载一次）。 */
-function ensureFallbackCover(): Promise<Buffer | null> {
-  if (fallbackCoverCache) return Promise.resolve(fallbackCoverCache.data);
-  return resolveCoverImage(FALLBACK_COVER_URL).then((data) => {
-    if (!fallbackCoverCache) {
-      fallbackCoverCache = { url: FALLBACK_COVER_URL, data };
-    }
-    return fallbackCoverCache.data;
-  });
-}
 
 const isAbortError = (error: unknown) =>
   error instanceof Error && (error.name === 'AbortError' || error.message === 'AbortError');
@@ -179,9 +163,6 @@ async function resolveCoverImage(url: string, signal?: AbortSignal): Promise<Buf
 export function initMediaControls(getMainWindow: () => BrowserWindow | null): void {
   nativeModule = loadNativeModule();
 
-  // 预热兜底封面，保证在真实封面缺失/失败时能立刻回退，避免任务栏黑窗
-  void ensureFallbackCover();
-
   if (!nativeModule) {
     log.warn('[MediaControls] Native addon unavailable, using fallback');
     registerFallbackIpc();
@@ -266,13 +247,8 @@ export function initMediaControls(getMainWindow: () => BrowserWindow | null): vo
       // 任务栏 DWM 缩略图需要及时响应系统请求，不能被 SMTC 的异步元数据更新挡住。
       // 仅在有可用封面时才更新为真实封面；切歌瞬间若新封面尚未就绪，
       // 保留上一张封面，避免 DWM 回退到实时窗口捕获而显示黑窗。
-      if (coverData) {
-        setTaskbarCover(coverData);
-      } else {
-        // 当前歌曲确实拿不到封面时，用应用的兜底封面兜底，同样避免黑窗。
-        const fallback = await ensureFallbackCover();
-        if (fallback) setTaskbarCover(fallback);
-      }
+      // 无真实封面时传 null，由 taskbarThumbnail 内部兜底封面机制负责回退。
+      setTaskbarCover(coverData);
 
       try {
         // native addon 期望 coverData 为 number[]（NAPI-RS 的 Vec<u8> 映射）

--- a/src/main/nowPlaying.ts
+++ b/src/main/nowPlaying.ts
@@ -10,6 +10,9 @@ import type {
 import { DEFAULT_NOW_PLAYING_APPEARANCE, DEFAULT_NOW_PLAYING_LYRIC } from '../shared/now-playing';
 import type { LyricLinePayload } from '../shared/lyrics';
 import type { IpcContext } from './ipc/types';
+import { getMainWindow } from './window';
+import { isCoverPreviewEnabled, setCoverPreviewEnabled } from './taskbarThumbnail';
+import { setMainAppSetting } from './storage/settings';
 
 const NOW_PLAYING_COMMANDS = new Set<NowPlayingCommand>([
   'togglePlayback',
@@ -165,6 +168,36 @@ const sendSnapshot = () => {
 
 export const getNowPlayingSnapshot = () => snapshot;
 
+const DEFAULT_WINDOW_TITLE = 'EchoMusic';
+
+/** 根据当前播放信息更新主窗口标题（任务栏/后台任务窗口显示）：歌手-歌名，无有效信息时回退 EchoMusic */
+const applyWindowTitle = (playback: NowPlayingPlaybackPayload | null | undefined) => {
+  const showTitle = isCoverPreviewEnabled();
+  const artist = showTitle ? String(playback?.artist ?? '').trim() : '';
+  const title = showTitle ? String(playback?.title ?? '').trim() : '';
+  const hasRealInfo = Boolean(
+    artist &&
+      title &&
+      artist !== '未知歌手' &&
+      title !== '未知歌曲' &&
+      artist !== 'Unknown Artist' &&
+      title !== 'Unknown',
+  );
+  const next = hasRealInfo ? `${artist} - ${title}` : DEFAULT_WINDOW_TITLE;
+  for (const win of BrowserWindow.getAllWindows()) {
+    try {
+      if (win.isDestroyed()) continue;
+      // 只更新主窗口（miniPlayer / desktopLyric 等独立窗口保持自己的标题）
+      if (win === getMainWindow()) {
+        if (win.getTitle() !== next) win.setTitle(next);
+        break;
+      }
+    } catch {
+      // ignore windows closing while updating title
+    }
+  }
+};
+
 export const syncNowPlayingSnapshot = (payload: NowPlayingSnapshotPatch) => {
   if (!payload || typeof payload !== 'object') return snapshot;
   snapshot = {
@@ -184,11 +217,19 @@ export const syncNowPlayingSnapshot = (payload: NowPlayingSnapshotPatch) => {
     updatedAt: Date.now(),
   };
   sendSnapshot();
+  applyWindowTitle(snapshot.playback);
   return snapshot;
 };
 
 export const registerNowPlayingHandlers = (context: IpcContext) => {
   ipcRegistry.registerHandler('now-playing:get-snapshot', () => getNowPlayingSnapshot());
+
+  // 任务栏封面预览开关：关闭时标题固定为 EchoMusic，并让任务栏回退到窗口实时画面
+  ipcRegistry.registerListener('update-taskbar-cover-preview', (_event, enabled: boolean) => {
+    setCoverPreviewEnabled(Boolean(enabled));
+    setMainAppSetting('taskbarCoverPreview', Boolean(enabled));
+    applyWindowTitle(snapshot.playback);
+  });
 
   ipcRegistry.registerListener(
     'now-playing:sync-snapshot',

--- a/src/main/storage/settings.ts
+++ b/src/main/storage/settings.ts
@@ -33,6 +33,7 @@ export type MainAppSettings = {
   highDpiEnabled: boolean;
   dpiScale: number;
   devToolsEnabled: boolean;
+  taskbarCoverPreview: boolean;
   windowState: MainWindowState;
   miniPlayerWindowState: MiniPlayerWindowState;
 };
@@ -59,6 +60,7 @@ export const DEFAULT_MAIN_APP_SETTINGS: MainAppSettings = {
   highDpiEnabled: false,
   dpiScale: 1,
   devToolsEnabled: false,
+  taskbarCoverPreview: false,
   windowState: {
     width: 1100,
     height: 750,

--- a/src/main/taskbarThumbnail.ts
+++ b/src/main/taskbarThumbnail.ts
@@ -231,10 +231,14 @@ export function setupTaskbarThumbnail(win: BrowserWindow): void {
 /** 更新当前封面（原始图片字节）。传 null 表示无可用封面，将回退到应用的兜底封面。 */
 export function setTaskbarCover(cover: Buffer | null): void {
   if (process.platform !== 'win32') return;
-  // 始终记录最新封面；开关关闭时 iconic 不会开启，重新开启后可立即显示当前封面
-  coverBuffer = cover && cover.length > 0 ? cover : null;
+  // coverData 为 null 时不立即清空 coverBuffer，保留上一张封面直至有真实封面替代，
+  // 避免切歌瞬间 coverBuffer=null 且兜底封面尚未就绪导致 DWM 预览黑窗。
+  // 只有传入真实封面时才更新 coverBuffer。
+  if (cover && cover.length > 0) {
+    coverBuffer = cover;
+  }
   if (!currentCover()) {
-    // 没有真实封面可用时确保兜底封面已加载，避免 iconic 无位图而显示黑窗
+    // 没有任何可用封面（首次启动/上一张已清空）时加载兜底封面作为安全网
     loadFallbackCover();
   }
   applyState();

--- a/src/main/taskbarThumbnail.ts
+++ b/src/main/taskbarThumbnail.ts
@@ -3,6 +3,7 @@ import { app } from 'electron';
 import { createRequire } from 'node:module';
 import path from 'path';
 import log from './logger';
+import { getMainAppSettings } from './storage/settings';
 
 /**
  * Windows 任务栏 iconic 缩略图。
@@ -33,9 +34,55 @@ let nativeModule: NativeTaskbar | null = null;
 let targetWindow: BrowserWindow | null = null;
 let hwndStr: string | null = null;
 let coverBuffer: Buffer | null = null;
+let fallbackCoverBuffer: Buffer | null = null;
+let fallbackCoverLoading = false;
 let iconicEnabled = false;
 let hooked = false;
+// 任务栏封面预览开关：关闭时走 DWM 默认实时窗口画面，不启用 iconic 封面
+let coverPreviewEnabled = false;
 const nativeRequire = createRequire(path.join(process.cwd(), 'package.json'));
+
+// 应用兜底封面：FORCE_ICONIC 开启后 DWM 只使用我们提供的位图，
+// 若封面缺失/下载中而不给位图，DWM 会渲染出黑窗。因此始终兜底一张封面。
+const FALLBACK_COVER_URL = 'https://imge.kugou.com/soft/collection/default.jpg';
+
+/** 当前可提供给 DWM 的封面位图：真实封面优先，缺失时用兜底封面 */
+function currentCover(): Buffer | null {
+  if (coverBuffer && coverBuffer.length > 0) return coverBuffer;
+  return fallbackCoverBuffer && fallbackCoverBuffer.length > 0 ? fallbackCoverBuffer : null;
+}
+
+/** 加载应用兜底封面（有在途/已加载则跳过） */
+function loadFallbackCover(): void {
+  if (fallbackCoverBuffer || fallbackCoverLoading) return;
+  fallbackCoverLoading = true;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
+  fetch(FALLBACK_COVER_URL, {
+    signal: controller.signal,
+    headers: {
+      'User-Agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      Referer: 'https://www.kugou.com/',
+    },
+  })
+    .then((res) => (res.ok ? res.arrayBuffer() : null))
+    .then((buf) => {
+      const data = buf && buf.byteLength > 0 ? Buffer.from(buf) : null;
+      if (data) {
+        fallbackCoverBuffer = data;
+        // 兜底封面就绪后若真实封面仍缺失，刷新一次缩略图
+        if (!coverBuffer) applyState();
+      }
+    })
+    .catch(() => {
+      // 加载失败保持 null，下次 setTaskbarCover 缺失封面时会重试
+    })
+    .finally(() => {
+      clearTimeout(timeout);
+      fallbackCoverLoading = false;
+    });
+}
 
 /** 加载 native addon（与 mediaControls 共用同一个 .node，require 缓存保证单例） */
 function loadNativeModule(): NativeTaskbar | null {
@@ -68,10 +115,10 @@ function resolveHwnd(win: BrowserWindow): string | null {
   }
 }
 
-/** 根据「是否有封面」决定开启或关闭 iconic 表示（有封面就显示封面，否则窗口实时预览） */
+/** 根据「是否有可用封面」决定开启或关闭 iconic 表示（有封面就显示封面，否则窗口实时预览） */
 function applyState(): void {
   if (!nativeModule || !hwndStr) return;
-  const shouldShowCover = !!coverBuffer;
+  const shouldShowCover = coverPreviewEnabled && !!currentCover();
   try {
     if (shouldShowCover) {
       if (!iconicEnabled) {
@@ -90,25 +137,12 @@ function applyState(): void {
   }
 }
 
-function disableIconicFallback(reason: string, err?: unknown): void {
-  if (!nativeModule || !hwndStr || !iconicEnabled) return;
-  try {
-    nativeModule.taskbarDisableIconic(hwndStr);
-    iconicEnabled = false;
-    nativeModule.taskbarInvalidate(hwndStr);
-    log.warn(`[TaskbarThumbnail] Disabled iconic thumbnail fallback: ${reason}`, err);
-  } catch (disableErr) {
-    log.warn('[TaskbarThumbnail] disable iconic fallback failed:', disableErr);
-  }
-}
-
 /** 处理悬停缩略图请求：从 lParam 解析最大尺寸并写入封面 */
 function onThumbnailRequest(lParam: Buffer): void {
   if (!nativeModule || !hwndStr) return;
-  if (!coverBuffer) {
-    disableIconicFallback('thumbnail requested without cover');
-    return;
-  }
+  // 封面暂缺时保留 DWM 已有的缩略图，避免回退到实时窗口捕获而黑屏
+  const cover = currentCover();
+  if (!cover) return;
   let maxWidth = DEFAULT_THUMBNAIL_MAX;
   let maxHeight = DEFAULT_THUMBNAIL_MAX;
   try {
@@ -122,25 +156,23 @@ function onThumbnailRequest(lParam: Buffer): void {
     // 解析失败则使用默认尺寸
   }
   try {
-    nativeModule.taskbarSetThumbnail(hwndStr, coverBuffer, maxWidth, maxHeight);
+    nativeModule.taskbarSetThumbnail(hwndStr, cover, maxWidth, maxHeight);
   } catch (err) {
-    log.warn('[TaskbarThumbnail] setThumbnail failed:', err);
-    disableIconicFallback('setThumbnail failed', err);
+    // 解码失败（不支持格式等）时保留 DWM 已有的缩略图，避免回退到实时窗口捕获而黑屏
+    log.warn('[TaskbarThumbnail] setThumbnail failed, keeping previous thumbnail:', err);
   }
 }
 
 /** 处理 Aero Peek 大预览请求：写入封面 */
 function onLivePreviewRequest(): void {
   if (!nativeModule || !hwndStr) return;
-  if (!coverBuffer) {
-    disableIconicFallback('live preview requested without cover');
-    return;
-  }
+  // 封面暂缺时保留 DWM 已有内容，避免回退到实时窗口捕获而黑屏
+  const cover = currentCover();
+  if (!cover) return;
   try {
-    nativeModule.taskbarSetLivePreview(hwndStr, coverBuffer, LIVE_PREVIEW_MAX, LIVE_PREVIEW_MAX);
+    nativeModule.taskbarSetLivePreview(hwndStr, cover, LIVE_PREVIEW_MAX, LIVE_PREVIEW_MAX);
   } catch (err) {
     log.warn('[TaskbarThumbnail] setLivePreview failed:', err);
-    disableIconicFallback('setLivePreview failed', err);
   }
 }
 
@@ -164,6 +196,12 @@ export function setupTaskbarThumbnail(win: BrowserWindow): void {
     return;
   }
 
+  // 预加载兜底封面，保证任何时刻都能向 DWM 提供位图，避免黑窗
+  loadFallbackCover();
+
+  // 从已持久化的主进程设置初始化任务栏封面预览开关
+  coverPreviewEnabled = Boolean(getMainAppSettings().taskbarCoverPreview);
+
   if (!hooked) {
     win.hookWindowMessage(WM_DWMSENDICONICTHUMBNAIL, (_wParam, lParam) => {
       onThumbnailRequest(lParam);
@@ -180,10 +218,27 @@ export function setupTaskbarThumbnail(win: BrowserWindow): void {
   log.info('[TaskbarThumbnail] Initialized');
 }
 
-/** 更新当前封面（原始图片字节）。传 null 表示无封面。 */
+/** 更新当前封面（原始图片字节）。传 null 表示无可用封面，将回退到应用的兜底封面。 */
 export function setTaskbarCover(cover: Buffer | null): void {
   if (process.platform !== 'win32') return;
+  // 开关关闭时忽略封面更新，任务栏保持窗口实时画面
+  if (!coverPreviewEnabled) return;
   coverBuffer = cover && cover.length > 0 ? cover : null;
+  if (!currentCover()) {
+    // 没有真实封面可用时确保兜底封面已加载，避免 iconic 无位图而显示黑窗
+    loadFallbackCover();
+  }
+  applyState();
+}
+
+/** 任务栏封面预览当前是否开启 */
+export function isCoverPreviewEnabled(): boolean {
+  return coverPreviewEnabled;
+}
+
+/** 设置任务栏封面预览开关（关闭时回退到 DWM 实时窗口画面） */
+export function setCoverPreviewEnabled(enabled: boolean): void {
+  coverPreviewEnabled = enabled;
   applyState();
 }
 
@@ -205,6 +260,7 @@ export function destroyTaskbarThumbnail(): void {
   iconicEnabled = false;
   hooked = false;
   coverBuffer = null;
+  fallbackCoverBuffer = null;
   hwndStr = null;
   targetWindow = null;
 }

--- a/src/main/taskbarThumbnail.ts
+++ b/src/main/taskbarThumbnail.ts
@@ -38,6 +38,8 @@ let fallbackCoverBuffer: Buffer | null = null;
 let fallbackCoverLoading = false;
 let iconicEnabled = false;
 let hooked = false;
+// 已应用的封面引用，用于避免对相同封面重复 invalidate
+let appliedCoverRef: Buffer | null = null;
 // 任务栏封面预览开关：关闭时走 DWM 默认实时窗口画面，不启用 iconic 封面
 let coverPreviewEnabled = false;
 const nativeRequire = createRequire(path.join(process.cwd(), 'package.json'));
@@ -115,22 +117,30 @@ function resolveHwnd(win: BrowserWindow): string | null {
   }
 }
 
-/** 根据「是否有可用封面」决定开启或关闭 iconic 表示（有封面就显示封面，否则窗口实时预览） */
+/** 开关由「任务栏封面预览」控制：开则始终显示封面（真实，缺失时用兜底），关则回落到 DWM 实时窗口画面 */
 function applyState(): void {
   if (!nativeModule || !hwndStr) return;
   const shouldShowCover = coverPreviewEnabled && !!currentCover();
   try {
     if (shouldShowCover) {
-      if (!iconicEnabled) {
+      const needEnable = !iconicEnabled;
+      if (needEnable) {
         nativeModule.taskbarEnableIconic(hwndStr);
         iconicEnabled = true;
       }
-      // 触发系统重新索取缩略图，换上当前封面
-      nativeModule.taskbarInvalidate(hwndStr);
-    } else if (iconicEnabled) {
-      nativeModule.taskbarDisableIconic(hwndStr);
-      iconicEnabled = false;
-      nativeModule.taskbarInvalidate(hwndStr);
+      // 封面已应用过且 iconic 已开启时无需重复触发系统重新索取
+      if (needEnable || appliedCoverRef !== coverBuffer) {
+        appliedCoverRef = coverBuffer;
+        // 触发系统重新索取缩略图，换上当前封面
+        nativeModule.taskbarInvalidate(hwndStr);
+      }
+    } else {
+      appliedCoverRef = null;
+      if (iconicEnabled) {
+        nativeModule.taskbarDisableIconic(hwndStr);
+        iconicEnabled = false;
+        nativeModule.taskbarInvalidate(hwndStr);
+      }
     }
   } catch (err) {
     log.warn('[TaskbarThumbnail] applyState failed:', err);
@@ -221,8 +231,7 @@ export function setupTaskbarThumbnail(win: BrowserWindow): void {
 /** 更新当前封面（原始图片字节）。传 null 表示无可用封面，将回退到应用的兜底封面。 */
 export function setTaskbarCover(cover: Buffer | null): void {
   if (process.platform !== 'win32') return;
-  // 开关关闭时忽略封面更新，任务栏保持窗口实时画面
-  if (!coverPreviewEnabled) return;
+  // 始终记录最新封面；开关关闭时 iconic 不会开启，重新开启后可立即显示当前封面
   coverBuffer = cover && cover.length > 0 ? cover : null;
   if (!currentCover()) {
     // 没有真实封面可用时确保兜底封面已加载，避免 iconic 无位图而显示黑窗
@@ -259,6 +268,7 @@ export function destroyTaskbarThumbnail(): void {
   }
   iconicEnabled = false;
   hooked = false;
+  appliedCoverRef = null;
   coverBuffer = null;
   fallbackCoverBuffer = null;
   hwndStr = null;

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -247,6 +247,7 @@ onMounted(async () => {
   settings.syncTheme();
   settings.syncCloseBehavior();
   settings.syncRememberWindowSize();
+  settings.syncTaskbarCoverPreview();
   settings.syncPreventSleep(player.isPlaying);
   settings.syncLogSettings();
   disposeShortcuts = initShortcutSync();

--- a/src/renderer/stores/setting.ts
+++ b/src/renderer/stores/setting.ts
@@ -127,6 +127,7 @@ export const useSettingStore = defineStore('setting', {
     pauseOnOutputDeviceDisconnect: false,
     showAudioQualityBadge: true,
     showDesktopLyricStatus: true,
+    taskbarCoverPreview: false,
     volumeNormalization: true,
     volumeNormalizationLufs: -14,
     impulseResponseEnabled: false,
@@ -309,6 +310,11 @@ export const useSettingStore = defineStore('setting', {
     syncStartMinimized() {
       if (window.electron?.ipcRenderer) {
         window.electron.ipcRenderer.send('update-start-minimized', this.startMinimized);
+      }
+    },
+    syncTaskbarCoverPreview() {
+      if (window.electron?.ipcRenderer) {
+        window.electron.ipcRenderer.send('update-taskbar-cover-preview', this.taskbarCoverPreview);
       }
     },
     syncDevToolsEnabled() {

--- a/src/renderer/views/settings/components/AppearanceSettingsSection.vue
+++ b/src/renderer/views/settings/components/AppearanceSettingsSection.vue
@@ -139,6 +139,20 @@ const resolvedTitle = computed(() => title.label);
     <div class="settings-divider"></div>
     <div class="settings-item">
       <div class="space-y-1">
+        <h3 class="font-semibold">任务栏封面预览</h3>
+        <p class="text-sm text-text-secondary">在任务栏窗口以及后台窗口显示封面和歌曲标题</p>
+      </div>
+      <Switch
+        :model-value="settingStore.taskbarCoverPreview"
+        @update:model-value="
+          settingStore.taskbarCoverPreview = Boolean($event);
+          settingStore.syncTaskbarCoverPreview();
+        "
+      />
+    </div>
+    <div class="settings-divider"></div>
+    <div class="settings-item">
+      <div class="space-y-1">
         <h3 class="font-semibold">播放列表计数</h3>
         <p class="text-sm text-text-secondary">在播放器播放列表图标上显示计数</p>
       </div>


### PR DESCRIPTION
## 改动内容

### 新增功能
- **任务栏封面预览开关**：在「设置 → 外观与界面」新增「任务栏封面预览」开关（默认关闭）
  - 开启：任务栏悬停/Aero Peek 显示歌曲封面 + 窗口标题显示「歌手 - 歌名」
  - 关闭：任务栏显示窗口实时画面 + 标题固定为 EchoMusic
- **无边框封面缩略图**：去掉 DWM 显示边框标志（DWM_SIT_DISPLAYFRAME），封面缩略图无边框显示

### 修复
- **切歌黑窗**：coverData 为空时不立即清空 coverBuffer，保留上一张封面直至有真实封面替代，避免切歌瞬间 DWM 预览黑窗

### 优化
- **兜底封面统一**：移除 mediaControls 中的兜底封面缓存，任务栏兜底统一收敛到 taskbarThumbnail，消除重复下载
- **开关切换即时生效**：setTaskbarCover 不再因开关关闭而早退，始终记录最新封面，重开开关可立即显示
- **invalidate 去重**：applyState 按封面 Buffer 引用对比，封面未变化时跳过重复的 DWM 重新解码

### 改动文件
- src/main/taskbarThumbnail.ts：核心逻辑
- src/main/mediaControls.ts：移除冗余兜底
- src/main/nowPlaying.ts：窗口标题 + 开关 IPC
- src/main/storage/settings.ts：持久化默认值
- 
ative/echo-media-controls/src/taskbar.rs：无边框标志
- src/renderer/views/settings/components/AppearanceSettingsSection.vue：UI 开关
- src/renderer/stores/setting.ts：渲染进程状态
- src/renderer/App.vue：启动同步