### PR TITLE
feat: 上传到云盘弹窗新增「匹配上传」选项

### DIFF
--- a/src/main/ipc/cloud.ts
+++ b/src/main/ipc/cloud.ts
@@ -46,6 +46,7 @@ const getUploadSizeLimitError = () => `文件为空或超过 ${formatUploadMaxSi
 const showPickDialog = (
   win: BrowserWindow | null,
   mode: 'file' | 'folder',
+  multi = true,
 ): Promise<Electron.OpenDialogReturnValue> => {
   const options: OpenDialogOptions =
     mode === 'folder'
@@ -55,7 +56,7 @@ const showPickDialog = (
         }
       : {
           title: '选择要上传的音乐文件',
-          properties: ['openFile', 'multiSelections'],
+          properties: multi ? ['openFile', 'multiSelections'] : ['openFile'],
           filters: [
             { name: '音频文件', extensions: [...CLOUD_UPLOAD_EXTENSIONS] },
             { name: '所有文件', extensions: ['*'] },
@@ -188,13 +189,13 @@ const readAllowedUploadFileData = async (
 export const registerCloudHandlers = (context: IpcContext) => {
   ipcRegistry.registerHandler(
     'cloud:pick-upload-files',
-    async (_event, mode: 'file' | 'folder'): Promise<CloudPickFilesResult> => {
+    async (_event, mode: 'file' | 'folder', multi = true): Promise<CloudPickFilesResult> => {
       if (mode !== 'file' && mode !== 'folder') {
         return { canceled: true, files: [] };
       }
 
       const win = context.getMainWindow();
-      const result = await showPickDialog(win, mode);
+      const result = await showPickDialog(win, mode, multi);
       if (result.canceled || result.filePaths.length === 0) {
         return { canceled: true, files: [] };
       }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -425,8 +425,8 @@ contextBridge.exposeInMainWorld('electron', {
     },
   },
   cloud: {
-    pickUploadFiles: (mode: CloudPickMode) =>
-      ipcRenderer.invoke('cloud:pick-upload-files', mode) as Promise<CloudPickFilesResult>,
+    pickUploadFiles: (mode: CloudPickMode, multi?: boolean) =>
+      ipcRenderer.invoke('cloud:pick-upload-files', mode, multi ?? true) as Promise<CloudPickFilesResult>,
     readUploadFileData: (filePath: string) =>
       ipcRenderer.invoke(
         'cloud:read-upload-file-data',

--- a/src/renderer/components/music/CloudUploadDialog.vue
+++ b/src/renderer/components/music/CloudUploadDialog.vue
@@ -371,6 +371,7 @@ const handleManualSearch = async () => {
       };
     });
     manualSearchDone.value = true;
+    scrollResultListToTop();
     if (manualResults.value.length === 0) {
       toastStore.warning('未找到匹配的歌曲，请修改搜索条件重试');
     }
@@ -381,12 +382,21 @@ const handleManualSearch = async () => {
   }
 };
 
+const manualSearchResultList = ref<InstanceType<typeof Scrollbar> | null>(null);
+
+const scrollResultListToTop = () => {
+  requestAnimationFrame(() => {
+    manualSearchResultList.value?.scrollTo({ top: 0 });
+  });
+};
+
 const handleSelectManualResult = async (result: ManualSearchResult) => {
   if (!manualFile.value) return;
   const item = manualFile.value;
   item.audioId = result.audioId;
   item.albumAudioId = result.albumAudioId;
   item.matchStatus = 'linked';
+  item.status = 'uploading';
   step.value = 'uploading';
   items.value = [item];
   canceled.value = false;
@@ -478,6 +488,9 @@ const statusLabel = (item: UploadItem) => {
     return `${uploadLabel} · ${linkLabel}`;
   }
   if (item.status === 'failed') return '失败';
+  if (item.matchStatus === 'not_found' || item.matchStatus === 'low_score' || item.matchStatus === 'no_cloud_ids' || item.matchStatus === 'failed') {
+    return '未关联 · 等待上传';
+  }
   return '等待中';
 };
 </script>
@@ -538,7 +551,7 @@ const statusLabel = (item: UploadItem) => {
 
     <!-- 手动匹配：搜索表单 -->
     <template v-else-if="step === 'manual-search'">
-      <div class="cloud-manual-search">
+      <div class="cloud-manual-search" @keydown.esc="step = 'pick'; manualFile = null">
         <div class="cloud-manual-file-info" v-if="manualFile">
           <span class="text-[12px] text-text-secondary/70 truncate">
             {{ manualFile.name }}（{{ (manualFile.size / 1024 / 1024).toFixed(1) }} MB）
@@ -549,18 +562,20 @@ const statusLabel = (item: UploadItem) => {
             v-model="manualSearchTitle"
             class="cloud-manual-input"
             placeholder="歌名（必填）"
+            @input="manualResults = []; manualSearchDone = false"
             @keydown.enter="handleManualSearch"
           />
           <input
             v-model="manualSearchArtist"
             class="cloud-manual-input"
             placeholder="歌手"
+            @input="manualResults = []; manualSearchDone = false"
             @keydown.enter="handleManualSearch"
           />
           <input
             v-model="manualSearchAlbum"
             class="cloud-manual-input"
-            placeholder="专辑（可选，用于辅助筛选）"
+            placeholder="专辑（可选）"
             @keydown.enter="handleManualSearch"
           />
         </div>
@@ -578,6 +593,7 @@ const statusLabel = (item: UploadItem) => {
         <div v-if="manualSearchDone" class="cloud-manual-results">
           <div class="text-[12px] font-semibold text-text-main mb-2">搜索结果（点击选择）</div>
           <Scrollbar
+            ref="manualSearchResultList"
             class="cloud-manual-result-list"
             :scrollbar-inset="3"
             :content-props="{ class: 'cloud-manual-result-list-content' }"

--- a/src/renderer/components/music/CloudUploadDialog.vue
+++ b/src/renderer/components/music/CloudUploadDialog.vue
@@ -10,9 +10,11 @@ import {
   iconCloudUpload,
   iconFolderOpen,
   iconLoader2,
+  iconSearch,
   iconUpload,
   iconX,
 } from '@/icons';
+import { search } from '@/api/search';
 import { uploadToCloud } from '@/api/user';
 import {
   explainCloudUploadMatchRejection,
@@ -64,10 +66,28 @@ interface UploadItem {
   error?: string;
 }
 
-const step = ref<'pick' | 'uploading' | 'done'>('pick');
+const step = ref<'pick' | 'manual-search' | 'uploading' | 'done'>('pick');
 const items = ref<UploadItem[]>([]);
 const canceled = ref(false);
 const picking = ref(false);
+
+// 手动匹配状态
+interface ManualSearchResult {
+  raw: unknown;
+  title: string;
+  artist: string;
+  album: string;
+  duration: number;
+  audioId?: string;
+  albumAudioId?: string;
+}
+const manualFile = ref<UploadItem | null>(null);
+const manualSearchTitle = ref('');
+const manualSearchArtist = ref('');
+const manualSearchAlbum = ref('');
+const manualSearching = ref(false);
+const manualResults = ref<ManualSearchResult[]>([]);
+const manualSearchDone = ref(false);
 
 /** 匹配并发数（复用导入歌单防风控节奏） */
 const MATCH_CONCURRENCY = 2;
@@ -102,6 +122,12 @@ const reset = () => {
   step.value = 'pick';
   items.value = [];
   canceled.value = false;
+  manualFile.value = null;
+  manualSearchTitle.value = '';
+  manualSearchArtist.value = '';
+  manualSearchAlbum.value = '';
+  manualResults.value = [];
+  manualSearchDone.value = false;
 };
 
 const handleClose = (value: boolean) => {
@@ -268,6 +294,112 @@ const handlePick = async (mode: PickMode) => {
   }
 };
 
+// --- 手动匹配 ---
+const handlePickManual = async () => {
+  if (!userStore.isLoggedIn || picking.value) return;
+  picking.value = true;
+  try {
+    const result = await window.electron.cloud.pickUploadFiles('file');
+    if (result.canceled) return;
+    if (result.files.length === 0) {
+      toastStore.warning(result.errors?.[0] || '没有可上传的音频文件');
+      return;
+    }
+    const f = result.files[0];
+    manualFile.value = {
+      name: f.name,
+      path: f.path,
+      title: f.title || f.name.replace(/\.[^.]+$/, ''),
+      artist: f.artist || '',
+      duration: f.duration || 0,
+      size: f.size,
+      extension: f.extension,
+      modifiedAt: f.modifiedAt,
+      status: 'pending',
+      matchStatus: 'pending',
+    };
+    manualSearchTitle.value = manualFile.value.title;
+    manualSearchArtist.value = manualFile.value.artist;
+    manualSearchAlbum.value = '';
+    manualResults.value = [];
+    manualSearchDone.value = false;
+    step.value = 'manual-search';
+  } catch (error) {
+    toastStore.danger(`选择文件失败：${(error as Error)?.message || String(error)}`);
+  } finally {
+    picking.value = false;
+  }
+};
+
+const handleManualSearch = async () => {
+  const keyword = [manualSearchTitle.value.trim(), manualSearchArtist.value.trim()]
+    .filter(Boolean)
+    .join(' ');
+  if (!keyword) {
+    toastStore.warning('请输入歌名或歌手');
+    return;
+  }
+  manualSearching.value = true;
+  manualSearchDone.value = false;
+  manualResults.value = [];
+  try {
+    const res = await search(keyword, 'song', 1, 30);
+    const data = (res as { data?: { lists?: unknown[] } })?.data ?? {};
+    const lists = Array.isArray(data.lists) ? data.lists : [];
+    manualResults.value = lists.map((item) => {
+      const record = item as Record<string, unknown>;
+      const singers = record.Singers as
+        | { name?: string; AuthorName?: string }[]
+        | undefined;
+      const artistStr =
+        singers?.map((s) => s.name || s.AuthorName || '').filter(Boolean).join(', ') ||
+        (record.SingerName as string) ||
+        '';
+      const duration = Number(record.Duration ?? 0);
+      return {
+        raw: item,
+        title: (record.SongName as string) || (record.FileName as string) || '',
+        artist: artistStr,
+        album: (record.AlbumName as string) || '',
+        duration: duration > 1000 ? Math.round(duration / 1000) : duration,
+        audioId: normalizePositiveNumericId(
+          record.Auditoid ?? record.Audioid ?? record.audio_id ?? record.fileid,
+        ),
+        albumAudioId: normalizePositiveNumericId(
+          record.MixSongID ?? record.mixsongid ?? record.album_audio_id,
+        ),
+      };
+    });
+    manualSearchDone.value = true;
+    if (manualResults.value.length === 0) {
+      toastStore.warning('未找到匹配的歌曲，请修改搜索条件重试');
+    }
+  } catch (error) {
+    toastStore.danger(`搜索失败：${(error as Error)?.message || String(error)}`);
+  } finally {
+    manualSearching.value = false;
+  }
+};
+
+const handleSelectManualResult = async (result: ManualSearchResult) => {
+  if (!manualFile.value) return;
+  const item = manualFile.value;
+  item.audioId = result.audioId;
+  item.albumAudioId = result.albumAudioId;
+  item.matchStatus = 'linked';
+  step.value = 'uploading';
+  items.value = [item];
+  canceled.value = false;
+  await runUpload();
+};
+
+const formatDuration = (sec: number) => {
+  if (!sec || !Number.isFinite(sec)) return '';
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${String(s).padStart(2, '0')}`;
+};
+
 const uploadSingleItem = async (item: UploadItem) => {
   const title = item.title || item.name.replace(/\.[^.]+$/, '');
   item.status = 'uploading';
@@ -375,8 +507,8 @@ const statusLabel = (item: UploadItem) => {
             <Icon :icon="iconUpload" width="20" height="20" />
           </div>
           <div class="min-w-0 flex-1 text-left">
-            <div class="text-[13px] font-semibold text-text-main">上传单曲</div>
-            <div class="text-[11px] text-text-secondary/75">支持多选，单文件不超过 100MB</div>
+            <div class="text-[13px] font-semibold text-text-main">上传歌曲</div>
+            <div class="text-[11px] text-text-secondary/75">上传时自动匹配歌曲信息，支持多选，单文件不超过 100MB</div>
           </div>
         </button>
         <button class="cloud-upload-option" :disabled="picking" @click="handlePick('folder')">
@@ -385,9 +517,89 @@ const statusLabel = (item: UploadItem) => {
           </div>
           <div class="min-w-0 flex-1 text-left">
             <div class="text-[13px] font-semibold text-text-main">上传文件夹</div>
-            <div class="text-[11px] text-text-secondary/75">自动收集文件夹内所有音频文件</div>
+            <div class="text-[11px] text-text-secondary/75">收集文件夹内所有音频文件后自动匹配上传</div>
           </div>
         </button>
+        <button
+          class="cloud-upload-option"
+          :disabled="picking"
+          @click="handlePickManual"
+        >
+          <div class="cloud-upload-option-icon">
+            <Icon :icon="iconSearch" width="20" height="20" />
+          </div>
+          <div class="min-w-0 flex-1 text-left">
+            <div class="text-[13px] font-semibold text-text-main">匹配上传</div>
+            <div class="text-[11px] text-text-secondary/75">上传时手动匹配歌曲信息，单文件不超过 100MB</div>
+          </div>
+        </button>
+      </div>
+    </template>
+
+    <!-- 手动匹配：搜索表单 -->
+    <template v-else-if="step === 'manual-search'">
+      <div class="cloud-manual-search">
+        <div class="cloud-manual-file-info" v-if="manualFile">
+          <span class="text-[12px] text-text-secondary/70 truncate">
+            {{ manualFile.name }}（{{ (manualFile.size / 1024 / 1024).toFixed(1) }} MB）
+          </span>
+        </div>
+        <div class="cloud-manual-form">
+          <input
+            v-model="manualSearchTitle"
+            class="cloud-manual-input"
+            placeholder="歌名（必填）"
+            @keydown.enter="handleManualSearch"
+          />
+          <input
+            v-model="manualSearchArtist"
+            class="cloud-manual-input"
+            placeholder="歌手"
+            @keydown.enter="handleManualSearch"
+          />
+          <input
+            v-model="manualSearchAlbum"
+            class="cloud-manual-input"
+            placeholder="专辑（可选，用于辅助筛选）"
+            @keydown.enter="handleManualSearch"
+          />
+        </div>
+        <Button
+          variant="primary"
+          size="sm"
+          class="self-end"
+          :disabled="manualSearching || !manualSearchTitle.trim()"
+          @click="handleManualSearch"
+        >
+          <Icon v-if="manualSearching" :icon="iconLoader2" width="14" height="14" class="animate-spin mr-1" />
+          <Icon v-else :icon="iconSearch" width="14" height="14" class="mr-1" />
+          搜索
+        </Button>
+        <div v-if="manualSearchDone" class="cloud-manual-results">
+          <div class="text-[12px] font-semibold text-text-main mb-2">搜索结果（点击选择）</div>
+          <Scrollbar
+            class="cloud-manual-result-list"
+            :scrollbar-inset="3"
+            :content-props="{ class: 'cloud-manual-result-list-content' }"
+          >
+            <div
+              v-for="(item, idx) in manualResults"
+              :key="idx"
+              class="cloud-manual-result-row"
+              @click="handleSelectManualResult(item)"
+            >
+              <div class="min-w-0 flex-1">
+                <div class="text-[13px] font-medium text-text-main truncate">{{ item.title }}</div>
+                <div class="text-[11px] text-text-secondary/70 truncate">
+                  {{ [item.artist, item.album].filter(Boolean).join(' · ') }}
+                </div>
+              </div>
+              <span class="text-[11px] text-text-secondary/60 shrink-0">
+                {{ formatDuration(item.duration) }}
+              </span>
+            </div>
+          </Scrollbar>
+        </div>
       </div>
     </template>
 
@@ -458,6 +670,10 @@ const statusLabel = (item: UploadItem) => {
     <template #footer>
       <template v-if="step === 'pick'">
         <Button variant="ghost" size="sm" :disabled="picking" @click="closeDialog">取消</Button>
+      </template>
+      <template v-else-if="step === 'manual-search'">
+        <Button variant="ghost" size="sm" @click="step = 'pick'; manualFile = null">返回</Button>
+        <Button variant="ghost" size="sm" @click="closeDialog">取消</Button>
       </template>
       <template v-else>
         <div class="cloud-upload-footer-content">
@@ -577,6 +793,62 @@ const statusLabel = (item: UploadItem) => {
 :global(.dialog-content.cloud-upload-dialog) {
   width: 460px;
   max-width: calc(100vw - 32px);
-  max-height: min(560px, calc(100vh - 64px));
+  max-height: min(580px, calc(100vh - 64px));
+}
+
+:global(.dialog-content.cloud-upload-dialog) .dialog-body {
+  @apply flex flex-col min-h-0 overflow-hidden;
+}
+
+.cloud-manual-search {
+  @apply flex flex-col gap-3 min-h-0 flex-1;
+  padding-right: 22px;
+}
+
+.cloud-manual-file-info {
+  @apply px-2 py-1.5 rounded-[6px];
+  background: var(--control-muted-bg);
+}
+
+.cloud-manual-form {
+  @apply flex flex-col gap-2;
+}
+
+.cloud-manual-input {
+  @apply w-full px-3 py-2 text-[13px] rounded-[8px] outline-none transition-colors;
+  background: var(--control-muted-bg);
+  border: 1px solid var(--border-subtle);
+  color: var(--color-text-main);
+}
+
+.cloud-manual-input::placeholder {
+  color: var(--color-text-secondary);
+  opacity: 0.6;
+}
+
+.cloud-manual-input:focus {
+  border-color: var(--color-primary);
+}
+
+.cloud-manual-results {
+  @apply flex flex-col min-h-0 flex-1;
+}
+
+.cloud-manual-result-list {
+  height: clamp(100px, calc(100vh - 500px), 180px);
+  min-height: 0;
+}
+
+:global(.cloud-manual-result-list-content) {
+  padding-right: 22px;
+  padding-bottom: 20px;
+}
+
+.cloud-manual-result-row {
+  @apply flex items-center gap-2.5 px-2 py-2 rounded-[8px] cursor-pointer transition-colors;
+}
+
+.cloud-manual-result-row:hover {
+  background: var(--control-hover-bg);
 }
 </style>

--- a/src/renderer/components/music/CloudUploadDialog.vue
+++ b/src/renderer/components/music/CloudUploadDialog.vue
@@ -299,7 +299,7 @@ const handlePickManual = async () => {
   if (!userStore.isLoggedIn || picking.value) return;
   picking.value = true;
   try {
-    const result = await window.electron.cloud.pickUploadFiles('file');
+    const result = await window.electron.cloud.pickUploadFiles('file', false);
     if (result.canceled) return;
     if (result.files.length === 0) {
       toastStore.warning(result.errors?.[0] || '没有可上传的音频文件');

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -269,7 +269,7 @@ export interface IElectronAPI {
     }>;
   };
   cloud: {
-    pickUploadFiles: (mode: CloudPickMode) => Promise<{
+    pickUploadFiles: (mode: CloudPickMode, multi?: boolean) => Promise<{
       canceled: boolean;
       files: {
         name: string;


### PR DESCRIPTION
- 上传到云盘弹窗新增「匹配上传」选项，点击后直接弹出文件选择器
- 选中文件后切换到搜索表单（歌名/歌手/专辑），搜索曲库并展示结果
- 用户选择结果后提取 audio_id 和 album_audio_id 进行上传
- 移除独立的 CloudManualUploadDialog 组件，全部逻辑收敛到 CloudUploadDialog
- 选择搜索结果后显示加载 spinner
- 搜索输入框编辑时清除旧结果
- 搜索结果返回后滚到顶部
- 手动搜索步支持 Esc 返回
- 未关联曲库的项显示「未关联 · 等待上传」提示