### PR TITLE
feat: 云盘歌曲无专辑封面时使用歌手头像兜底

### DIFF
--- a/src/renderer/models/song.ts
+++ b/src/renderer/models/song.ts
@@ -23,6 +23,7 @@ export interface CloudAudioSource {
 export interface SongArtist {
   id?: string | number;
   name: string;
+  pic?: string;
 }
 
 export interface Song {

--- a/src/renderer/utils/mappers/shared.ts
+++ b/src/renderer/utils/mappers/shared.ts
@@ -84,9 +84,13 @@ export const buildArtists = (record: UnknownRecord, audioInfo: UnknownRecord): S
       ).trim();
       if (!name) continue;
       const id = pickValue(raw.id, raw.AuthorId, raw.author_id, raw.singerid, raw.singer_id);
+      const pic = formatPic(
+        pickValue(raw.sizable_avatar, raw.avatar, raw.pic, raw.img, raw.image, ''),
+      );
       artists.push({
         id: id !== undefined && id !== null ? readString(id) : undefined,
         name,
+        pic: pic || undefined,
       });
     }
   }

--- a/src/renderer/utils/mappers/song.ts
+++ b/src/renderer/utils/mappers/song.ts
@@ -691,9 +691,12 @@ export const mapCloudSong = (json: unknown): Song => {
   const albumName = normalizeText(
     readString(pickValue(record.albumname, record.album_name, albumInfo.album_name, '')),
   );
-  const cover = formatPic(
-    pickValue(record.cover, record.pic, albumInfo.sizable_cover, transParam.union_cover, ''),
+  let cover = formatPic(
+    pickValue(record.cover, record.pic, record.img, record.album_sizable_cover, audioInfo.img, albumInfo.sizable_cover, transParam.union_cover, albumInfo.cover, ''),
   );
+  if (!cover && parsedSingers.length > 0 && parsedSingers[0].pic) {
+    cover = parsedSingers[0].pic;
+  }
   const durationRaw = parseIntSafe(
     pickValue(record.duration, record.timelen, audioInfo.duration, audioInfo.duration_128, 0),
   );


### PR DESCRIPTION
- SongArtist 模型新增 pic 字段存储歌手头像
- buildArtists 从 singerinfo/authors 提取 sizable_avatar/avatar 等头像字段
- mapCloudSong 封面为空时用第一个歌手的头像兜底
- 补齐云盘歌曲封面候选字段（与歌单一致）