### PR TITLE
feat: 云盘页面播放音乐默认直接使用云盘文件

### DIFF
--- a/src/renderer/stores/player/playback.ts
+++ b/src/renderer/stores/player/playback.ts
@@ -625,7 +625,7 @@ export const createPlaybackManager = (
     state.currentAudioCandidateIndex = -1;
     state.currentResolvedAudioQuality = null;
     state.currentResolvedAudioEffect = 'none';
-    state.currentResolvedSourceKind = 'catalog';
+    state.currentResolvedSourceKind = track.source === 'cloud' ? 'cloud' : 'catalog';
     state.nativeTrackSeq = null;
     state.currentTime = 0;
     state.currentTimeUpdatedAt = Date.now();

--- a/src/renderer/stores/player/resolver.ts
+++ b/src/renderer/stores/player/resolver.ts
@@ -369,6 +369,12 @@ export const createResolver = (
       return resolved;
     };
 
+    // 云盘页面播放的歌曲直接使用云盘文件，跳过优先级链（手动选择曲库音质时除外）
+    if (!shouldUseCatalogSource && track.source === 'cloud' && track.cloudAudioSource?.hash) {
+      const resolved = await resolveCloudAudioSourceUrl(track.cloudAudioSource);
+      if (resolved) return resolved;
+    }
+
     const pluginResolved = await resolvePluginAudioSource({
       track,
       quality: audioQuality,


### PR DESCRIPTION
- resolver 对 source=cloud 的歌曲直接解析云盘 URL，跳过优先级链
- 手动选择曲库音质时跳过快速路径，仍走正常优先级链
- playback 设置 snapshot 时立即标记 sourceKind=cloud，质量图标不闪烁