### PR TITLE
fix: Windows 下本地快捷键绕过输入法抢占 + 注册逻辑重构

### DIFF
--- a/src/main/ipc/shortcuts.ts
+++ b/src/main/ipc/shortcuts.ts
@@ -10,12 +10,19 @@ import type {
   ShortcutCommand,
   ShortcutMap,
   ShortcutRegistrationFailure,
+  ShortcutRegistrationRequest,
   ShortcutRegistrationResult,
 } from '../../shared/shortcuts';
 import type { IpcContext } from './types';
 
 let requestedShortcuts: ShortcutMap | null = null;
 const appRegisteredAccelerators = new Set<string>();
+
+let requestedLocalShortcuts: ShortcutMap | null = null;
+let localShortcutsEnabled = false;
+let localEditableSuspend = false;
+const appRegisteredLocalAccelerators = new Set<string>();
+let localShortcutFocusBound = false;
 
 type PluginGlobalShortcutRecord = {
   pluginId: string;
@@ -40,6 +47,13 @@ const unregisterAppShortcuts = () => {
     globalShortcut.unregister(accelerator);
   }
   appRegisteredAccelerators.clear();
+};
+
+const unregisterLocalShortcuts = () => {
+  for (const accelerator of appRegisteredLocalAccelerators) {
+    globalShortcut.unregister(accelerator);
+  }
+  appRegisteredLocalAccelerators.clear();
 };
 
 const unregisterPluginGlobalShortcutByKey = (key: string) => {
@@ -131,6 +145,76 @@ const registerShortcuts = (
   return { registered, failures };
 };
 
+// 无修饰键的独立按键（如 F5、Space）保留渲染层 keydown 处理，保留输入框守卫
+const MODIFIER_ACCELERATOR_PATTERN = /CmdOrCtrl|Ctrl|Shift|Alt|Meta/i;
+
+const registerLocalShortcuts = (
+  shortcutMap: ShortcutMap,
+  getMainWindow: () => BrowserWindow | null,
+): ShortcutRegistrationResult => {
+  unregisterLocalShortcuts();
+  const registered = {} as ShortcutMap;
+  const failures: ShortcutRegistrationFailure[] = [];
+
+  (Object.entries(shortcutMap) as Array<[ShortcutCommand, string]>).forEach(
+    ([command, accelerator]) => {
+      if (!accelerator) return;
+      if (!MODIFIER_ACCELERATOR_PATTERN.test(accelerator)) return;
+      try {
+        const didRegister = globalShortcut.register(accelerator, () => {
+          const win = getMainWindow();
+          // 本地快捷键仅在应用窗口聚焦时生效，避免在后台/全局触发
+          if (!win || win.isDestroyed() || !win.isFocused()) return;
+          if (command === 'toggleWindow') {
+            if (win.isVisible()) hideMainWindow();
+            else void restoreActiveWindowMode();
+            return;
+          }
+          if (command === 'toggleMiniPlayer') {
+            void toggleMiniPlayerWindow();
+            return;
+          }
+          forwardToRenderer(command, getMainWindow);
+        });
+        if (didRegister && globalShortcut.isRegistered(accelerator)) {
+          registered[command] = accelerator;
+          appRegisteredLocalAccelerators.add(accelerator);
+        } else {
+          failures.push({ command, accelerator, reason: 'conflict' });
+        }
+      } catch {
+        failures.push({ command, accelerator, reason: 'invalid' });
+      }
+    },
+  );
+  return { registered, failures };
+};
+
+const syncLocalShortcuts = (
+  getMainWindow: () => BrowserWindow | null,
+): ShortcutRegistrationResult | null => {
+  if (!localShortcutsEnabled || !requestedLocalShortcuts) {
+    unregisterLocalShortcuts();
+    return null;
+  }
+  const win = getMainWindow();
+  if (!win || win.isDestroyed()) {
+    unregisterLocalShortcuts();
+    return null;
+  }
+  // 输入框等可编辑上下文激活时暂停，让出输入法对 Ctrl+Space 等组合键的占用
+  if (localEditableSuspend) {
+    unregisterLocalShortcuts();
+    return null;
+  }
+  // 仅主窗口聚焦时注册本地快捷键，失焦即注销，保证其他应用不被抢占
+  if (win.isFocused()) {
+    return registerLocalShortcuts(requestedLocalShortcuts, getMainWindow);
+  }
+  unregisterLocalShortcuts();
+  return null;
+};
+
 const registerPluginGlobalShortcut = (
   webContents: WebContents,
   payload: PluginGlobalShortcutRegistrationPayload,
@@ -185,13 +269,36 @@ const registerPluginGlobalShortcut = (
 export const registerShortcutHandlers = ({ getMainWindow }: IpcContext) => {
   ipcRegistry.registerHandler(
     'shortcuts:register',
-    (_event, payload: { enabled: boolean; shortcutMap: ShortcutMap }) => {
+    (_event, payload: ShortcutRegistrationRequest) => {
+      let result: ShortcutRegistrationResult;
       if (!payload?.enabled) {
         unregisterAppShortcuts();
         requestedShortcuts = null;
-        return { registered: {} as ShortcutMap, failures: [] };
+        result = { registered: {} as ShortcutMap, failures: [] };
+      } else {
+        result = registerShortcuts(payload.shortcutMap, getMainWindow);
       }
-      return registerShortcuts(payload.shortcutMap, getMainWindow);
+
+      // 本地快捷键：Windows 下系统级注册以绕过输入法对 Ctrl+Space 等组合键的抢占，仅聚焦时生效
+      requestedLocalShortcuts = payload.localShortcutMap ?? null;
+      localShortcutsEnabled = Boolean(payload.localEnabled);
+      const win = getMainWindow();
+      if (win && !win.isDestroyed() && !localShortcutFocusBound) {
+        localShortcutFocusBound = true;
+        win.on('focus', () => syncLocalShortcuts(getMainWindow));
+        win.on('blur', () => syncLocalShortcuts(getMainWindow));
+        win.once('closed', () => {
+          localShortcutFocusBound = false;
+          unregisterLocalShortcuts();
+        });
+      }
+      const localResult = syncLocalShortcuts(getMainWindow);
+      if (localResult) {
+        for (const failure of localResult.failures) {
+          result.failures.push(failure);
+        }
+      }
+      return result;
     },
   );
 
@@ -199,7 +306,14 @@ export const registerShortcutHandlers = ({ getMainWindow }: IpcContext) => {
     if (!requestedShortcuts) {
       return { registered: {} as ShortcutMap, failures: [] };
     }
-    return registerShortcuts(requestedShortcuts, getMainWindow);
+    const result = registerShortcuts(requestedShortcuts, getMainWindow);
+    syncLocalShortcuts(getMainWindow);
+    return result;
+  });
+
+  ipcRegistry.registerHandler('shortcuts:set-local-editable-active', (_event, active: boolean) => {
+    localEditableSuspend = Boolean(active);
+    syncLocalShortcuts(getMainWindow);
   });
 
   ipcRegistry.registerHandler(

--- a/src/main/ipc/shortcuts.ts
+++ b/src/main/ipc/shortcuts.ts
@@ -104,36 +104,44 @@ const forwardToRenderer = (command: ShortcutCommand, getMainWindow: () => Browse
   win.webContents.send('shortcut-trigger', command);
 };
 
-const registerShortcuts = (
-  shortcutMap: ShortcutMap,
+const handleShortcutTrigger = (
+  command: ShortcutCommand,
   getMainWindow: () => BrowserWindow | null,
+  isEligible: (win: BrowserWindow | null) => boolean,
+) => {
+  if (!isEligible(getMainWindow())) return;
+  if (command === 'toggleWindow') {
+    const win = getMainWindow();
+    if (!win) return;
+    if (win.isVisible()) hideMainWindow();
+    else void restoreActiveWindowMode();
+    return;
+  }
+  if (command === 'toggleMiniPlayer') {
+    void toggleMiniPlayerWindow();
+    return;
+  }
+  forwardToRenderer(command, getMainWindow);
+};
+
+const registerAcceleratorMap = (
+  shortcutMap: ShortcutMap,
+  registeredSet: Set<string>,
+  handleTrigger: (command: ShortcutCommand) => void,
+  shouldRegister?: (accelerator: string) => boolean,
 ): ShortcutRegistrationResult => {
-  unregisterAppShortcuts();
   const registered = {} as ShortcutMap;
   const failures: ShortcutRegistrationFailure[] = [];
-  requestedShortcuts = shortcutMap;
 
   (Object.entries(shortcutMap) as Array<[ShortcutCommand, string]>).forEach(
     ([command, accelerator]) => {
       if (!accelerator) return;
+      if (shouldRegister && !shouldRegister(accelerator)) return;
       try {
-        const didRegister = globalShortcut.register(accelerator, () => {
-          if (command === 'toggleWindow') {
-            const win = getMainWindow();
-            if (!win) return;
-            if (win.isVisible()) hideMainWindow();
-            else void restoreActiveWindowMode();
-            return;
-          }
-          if (command === 'toggleMiniPlayer') {
-            void toggleMiniPlayerWindow();
-            return;
-          }
-          forwardToRenderer(command, getMainWindow);
-        });
+        const didRegister = globalShortcut.register(accelerator, () => handleTrigger(command));
         if (didRegister && globalShortcut.isRegistered(accelerator)) {
           registered[command] = accelerator;
-          appRegisteredAccelerators.add(accelerator);
+          registeredSet.add(accelerator);
         } else {
           failures.push({ command, accelerator, reason: 'conflict' });
         }
@@ -145,6 +153,17 @@ const registerShortcuts = (
   return { registered, failures };
 };
 
+const registerShortcuts = (
+  shortcutMap: ShortcutMap,
+  getMainWindow: () => BrowserWindow | null,
+): ShortcutRegistrationResult => {
+  unregisterAppShortcuts();
+  requestedShortcuts = shortcutMap;
+  return registerAcceleratorMap(shortcutMap, appRegisteredAccelerators, (command) =>
+    handleShortcutTrigger(command, getMainWindow, () => true),
+  );
+};
+
 // 无修饰键的独立按键（如 F5、Space）保留渲染层 keydown 处理，保留输入框守卫
 const MODIFIER_ACCELERATOR_PATTERN = /CmdOrCtrl|Ctrl|Shift|Alt|Meta/i;
 
@@ -153,41 +172,15 @@ const registerLocalShortcuts = (
   getMainWindow: () => BrowserWindow | null,
 ): ShortcutRegistrationResult => {
   unregisterLocalShortcuts();
-  const registered = {} as ShortcutMap;
-  const failures: ShortcutRegistrationFailure[] = [];
-
-  (Object.entries(shortcutMap) as Array<[ShortcutCommand, string]>).forEach(
-    ([command, accelerator]) => {
-      if (!accelerator) return;
-      if (!MODIFIER_ACCELERATOR_PATTERN.test(accelerator)) return;
-      try {
-        const didRegister = globalShortcut.register(accelerator, () => {
-          const win = getMainWindow();
-          // 本地快捷键仅在应用窗口聚焦时生效，避免在后台/全局触发
-          if (!win || win.isDestroyed() || !win.isFocused()) return;
-          if (command === 'toggleWindow') {
-            if (win.isVisible()) hideMainWindow();
-            else void restoreActiveWindowMode();
-            return;
-          }
-          if (command === 'toggleMiniPlayer') {
-            void toggleMiniPlayerWindow();
-            return;
-          }
-          forwardToRenderer(command, getMainWindow);
-        });
-        if (didRegister && globalShortcut.isRegistered(accelerator)) {
-          registered[command] = accelerator;
-          appRegisteredLocalAccelerators.add(accelerator);
-        } else {
-          failures.push({ command, accelerator, reason: 'conflict' });
-        }
-      } catch {
-        failures.push({ command, accelerator, reason: 'invalid' });
-      }
-    },
+  return registerAcceleratorMap(
+    shortcutMap,
+    appRegisteredLocalAccelerators,
+    (command) =>
+      handleShortcutTrigger(command, getMainWindow, (win) =>
+        Boolean(win && !win.isDestroyed() && win.isFocused()),
+      ),
+    (accelerator) => MODIFIER_ACCELERATOR_PATTERN.test(accelerator),
   );
-  return { registered, failures };
 };
 
 const syncLocalShortcuts = (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,7 +7,7 @@ import type {
   PluginGlobalShortcutRegistrationPayload,
   PluginGlobalShortcutRegistrationResult,
   PluginGlobalShortcutTriggerPayload,
-  ShortcutMap,
+  ShortcutRegistrationRequest,
   ShortcutRegistrationResult,
 } from '../shared/shortcuts';
 import type {
@@ -299,9 +299,11 @@ contextBridge.exposeInMainWorld('electron', {
     },
   },
   shortcuts: {
-    register: (payload: { enabled: boolean; shortcutMap: ShortcutMap }) =>
+    register: (payload: ShortcutRegistrationRequest) =>
       invokeWithPlainPayload<ShortcutRegistrationResult>('shortcuts:register', payload),
     refresh: () => ipcRenderer.invoke('shortcuts:refresh') as Promise<ShortcutRegistrationResult>,
+    setLocalEditableActive: (active: boolean) =>
+      ipcRenderer.invoke('shortcuts:set-local-editable-active', active),
     registerPluginGlobal: (payload: PluginGlobalShortcutRegistrationPayload) =>
       invokeWithPlainPayload<PluginGlobalShortcutRegistrationResult>(
         'shortcuts:register-plugin-global',

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -438,7 +438,12 @@ watch(
   },
 );
 watch(
-  () => [settings.globalShortcutsEnabled, settings.globalShortcutBindings],
+  () => [
+    settings.globalShortcutsEnabled,
+    settings.globalShortcutBindings,
+    settings.shortcutEnabled,
+    settings.shortcutBindings,
+  ],
   () => {
     if (!isMiniPlayerRoute.value) void syncGlobalShortcutsFn?.();
   },

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -10,7 +10,7 @@ import type {
   PluginGlobalShortcutRegistrationPayload,
   PluginGlobalShortcutRegistrationResult,
   PluginGlobalShortcutTriggerPayload,
-  ShortcutMap,
+  ShortcutRegistrationRequest,
   ShortcutRegistrationResult,
 } from '../shared/shortcuts';
 import type {
@@ -208,11 +208,9 @@ export interface IElectronAPI {
     off: (channel: string, func: (...args: unknown[]) => void) => void;
   };
   shortcuts: {
-    register: (payload: {
-      enabled: boolean;
-      shortcutMap: ShortcutMap;
-    }) => Promise<ShortcutRegistrationResult>;
+    register: (payload: ShortcutRegistrationRequest) => Promise<ShortcutRegistrationResult>;
     refresh: () => Promise<ShortcutRegistrationResult>;
+    setLocalEditableActive: (active: boolean) => Promise<void>;
     registerPluginGlobal: (
       payload: PluginGlobalShortcutRegistrationPayload,
     ) => Promise<PluginGlobalShortcutRegistrationResult>;

--- a/src/renderer/utils/shortcuts.ts
+++ b/src/renderer/utils/shortcuts.ts
@@ -434,7 +434,7 @@ const showGlobalShortcutFailures = (result: ShortcutRegistrationResult | null | 
       return `${label} (${displayAccelerator}) ${suffix}`;
     })
     .join('；');
-  toastStore.warning(`以下全局快捷键未生效：${message}`, 4200);
+  toastStore.warning(`以下快捷键未生效：${message}`, 4200);
 };
 
 export const executeShortcutCommand = (command: ShortcutCommand) => {
@@ -552,13 +552,14 @@ export const syncGlobalShortcuts = async () => {
   const settingStore = useSettingStore();
   const shortcutMap = resolveShortcutMap('global');
   const enabled = settingStore.globalShortcutsEnabled;
+  // Windows 下输入法会抢占 Ctrl+Space 等组合键，需系统级注册本地快捷键以绕过；
+  // 仅主窗口聚焦时生效，其他平台维持渲染层 keydown 监听
+  const localEnabled = window.electron?.platform === 'win32' && settingStore.shortcutEnabled;
   const result = await window.electron?.shortcuts?.register({
     enabled,
     shortcutMap,
-    // Windows 下输入法会抢占 Ctrl+Space 等组合键，需系统级注册本地快捷键以绕过；
-    // 仅主窗口聚焦时生效，其他平台维持渲染层 keydown 监听
-    localEnabled: window.electron?.platform === 'win32' && settingStore.shortcutEnabled,
-    localShortcutMap: resolveShortcutMap('local'),
+    localEnabled,
+    localShortcutMap: localEnabled ? resolveShortcutMap('local') : undefined,
   });
   showGlobalShortcutFailures(result);
 };
@@ -580,9 +581,12 @@ export const initShortcutSync = () => {
 
 // 输入框等可编辑上下文激活时，暂停本地系统级快捷键，让出输入法对 Ctrl+Space 等组合键的占用
 const watchEditableContext = () => {
+  let lastEditable: boolean | null = null;
   const sync = () => {
     const activeElement = document.activeElement;
     const editable = activeElement instanceof HTMLElement && isInEditableContext(activeElement);
+    if (editable === lastEditable) return;
+    lastEditable = editable;
     void window.electron?.shortcuts?.setLocalEditableActive(editable);
   };
 

--- a/src/renderer/utils/shortcuts.ts
+++ b/src/renderer/utils/shortcuts.ts
@@ -552,19 +552,46 @@ export const syncGlobalShortcuts = async () => {
   const settingStore = useSettingStore();
   const shortcutMap = resolveShortcutMap('global');
   const enabled = settingStore.globalShortcutsEnabled;
-  const result = await window.electron?.shortcuts?.register({ enabled, shortcutMap });
+  const result = await window.electron?.shortcuts?.register({
+    enabled,
+    shortcutMap,
+    // Windows 下输入法会抢占 Ctrl+Space 等组合键，需系统级注册本地快捷键以绕过；
+    // 仅主窗口聚焦时生效，其他平台维持渲染层 keydown 监听
+    localEnabled: window.electron?.platform === 'win32' && settingStore.shortcutEnabled,
+    localShortcutMap: resolveShortcutMap('local'),
+  });
   showGlobalShortcutFailures(result);
 };
 
 export const initShortcutSync = () => {
   const removeLocal = registerLocalShortcuts();
   void syncGlobalShortcuts();
+  const removeEditableWatch = watchEditableContext();
   const removeGlobal = window.electron?.shortcuts?.onTrigger((command) => {
     if (!command) return;
     executeShortcutCommand(command as ShortcutCommand);
   });
   return () => {
     removeLocal();
+    removeEditableWatch();
     if (typeof removeGlobal === 'function') removeGlobal();
+  };
+};
+
+// 输入框等可编辑上下文激活时，暂停本地系统级快捷键，让出输入法对 Ctrl+Space 等组合键的占用
+const watchEditableContext = () => {
+  const sync = () => {
+    const activeElement = document.activeElement;
+    const editable = activeElement instanceof HTMLElement && isInEditableContext(activeElement);
+    void window.electron?.shortcuts?.setLocalEditableActive(editable);
+  };
+
+  window.addEventListener('focusin', sync);
+  window.addEventListener('focusout', sync);
+  sync();
+
+  return () => {
+    window.removeEventListener('focusin', sync);
+    window.removeEventListener('focusout', sync);
   };
 };

--- a/src/shared/shortcuts.ts
+++ b/src/shared/shortcuts.ts
@@ -31,6 +31,13 @@ export interface ShortcutRegistrationResult {
   failures: ShortcutRegistrationFailure[];
 }
 
+export interface ShortcutRegistrationRequest {
+  enabled: boolean;
+  shortcutMap: ShortcutMap;
+  localEnabled?: boolean;
+  localShortcutMap?: ShortcutMap;
+}
+
 export interface PluginGlobalShortcutRegistrationPayload {
   pluginId: string;
   registrationId: string;


### PR DESCRIPTION
## 修复
- Windows 下输入法会抢占 Ctrl+Space，导致本地播放/暂停快捷键失效。现改为本地快捷键系统级注册（绕过输入法），仅主窗口聚焦时生效、失焦注销；输入框等可编辑上下文激活时暂停，让出输入法。
- 非 Windows 平台行为不变（仍走渲染层 keydown）。

## 重构
- 统一 main 侧快捷键注册逻辑（registerAcceleratorMap + handleShortcutTrigger），消除重复代码。
- 渲染层按需计算本地 map、去重可编辑上下文 IPC。

## 验证
- tsc / eslint 通过