### PR TITLE
fix: 收藏专辑时侧边栏不再跳转到收藏歌单

### DIFF
--- a/src/renderer/layouts/Sidebar.vue
+++ b/src/renderer/layouts/Sidebar.vue
@@ -672,14 +672,6 @@ watch(
       }
       return;
     }
-
-    if (route.name === 'album-detail') {
-      const currentId = activeAlbumRouteId.value;
-      const matched = findPlaylistByRouteId(currentId, 2);
-      if (matched) {
-        activePlaylistTab.value = 1;
-      }
-    }
   },
   { immediate: true },
 );


### PR DESCRIPTION
## 修复内容

收藏专辑时，左侧侧边栏会错误地跳转到收藏歌单tab。

## 根因

 中的 watcher 监听了 ，当用户在专辑详情页收藏专辑后， 触发 watcher，由于当前路由是 ，watcher 会将  设为 1（收藏歌单）。

但两个侧边栏 tab 都过滤掉了  的专辑，专辑根本不会在侧边栏显示，切换 tab 毫无意义。

## 修复

删除  中 watcher 的  分支（原 676-682 行），收藏专辑时侧边栏保持当前 tab 不变。