### PR TITLE
修复 Linux 标题栏按钮重叠

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1563,15 +1563,29 @@ const controlsOverlay = (
     windowControlsOverlay?: EventTarget & { visible: boolean; getTitlebarAreaRect(): DOMRect };
   }
 ).windowControlsOverlay;
+let lastTitlebarArea: { x: number; width: number } | null = null;
 const syncWindowZoomGeometry = () => {
   const root = document.documentElement;
   if (!root) return;
   const factor = webFrame.getZoomFactor();
   root.style.setProperty('--window-zoom-factor', String(factor));
+  // Electron can briefly report an empty WCO rectangle while the transparent
+  // window is being recomposed. Keep the last valid safe area for that frame so
+  // the app's right-side actions cannot move underneath the native close button.
+  const overlayVisible = controlsOverlay?.visible === true;
+  const reportedRect =
+    !nativeFullscreen && overlayVisible ? controlsOverlay.getTitlebarAreaRect() : null;
+  if (reportedRect && reportedRect.width > 0 && Number.isFinite(reportedRect.x)) {
+    lastTitlebarArea = { x: reportedRect.x, width: reportedRect.width };
+  }
   // Fullscreen returns an empty rectangle; never reserve an entire viewport for it.
   const fullscreen = nativeFullscreen || Boolean(document.fullscreenElement);
   const rect =
-    !fullscreen && controlsOverlay?.visible ? controlsOverlay.getTitlebarAreaRect() : null;
+    !fullscreen && overlayVisible
+      ? reportedRect && reportedRect.width > 0
+        ? reportedRect
+        : lastTitlebarArea
+      : null;
   const inset = rect && rect.width > 0 ? Math.max(0, window.innerWidth - rect.x - rect.width) : 0;
   // macOS keeps the 14/14 traffic-light anchor aligned with the collapsed sidebar.
   // Reserve its 80x46 DIP strip centrally; WCO may report a wider safe area.
@@ -1599,6 +1613,12 @@ document.addEventListener('fullscreenchange', () => {
   requestAnimationFrame(syncWindowZoomGeometry);
 });
 ipcRenderer.on('window:zoom-changed', syncWindowZoomGeometry);
+// setTitleBarOverlay() and transparent-window composition update asynchronously
+// on Linux. Re-read the WCO safe area after the background preference changes.
+ipcRenderer.on('window-background:changed', () => {
+  syncWindowZoomGeometry();
+  window.requestAnimationFrame(syncWindowZoomGeometry);
+});
 controlsOverlay?.addEventListener('geometrychange', syncWindowZoomGeometry);
 window.addEventListener('resize', syncWindowZoomGeometry);
 window.addEventListener('DOMContentLoaded', syncWindowZoomGeometry, { once: true });

--- a/src/renderer/layouts/WindowControls.vue
+++ b/src/renderer/layouts/WindowControls.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import Button from '@/components/ui/Button.vue';
-import { iconFullscreen, iconPictureInPicture } from '@/icons';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { iconFullscreen, iconPictureInPicture, iconX } from '@/icons';
 import { useSettingStore } from '@/stores/setting';
 withDefaults(defineProps<{ showMiniPlayer?: boolean }>(), { showMiniPlayer: false });
 const settings = useSettingStore();
@@ -9,6 +10,21 @@ const openMiniPlayer = () => {
 };
 const toggleFullscreen = () => window.electron.windowControl('fullscreen');
 const isMac = window.electron.platform === 'darwin';
+const isLinux = window.electron.platform === 'linux';
+const controlsOverlay = (
+  navigator as Navigator & { windowControlsOverlay?: EventTarget & { visible: boolean } }
+).windowControlsOverlay;
+const nativeControlsVisible = ref(!isLinux || controlsOverlay?.visible === true);
+const showFallbackClose = computed(() => isLinux && !nativeControlsVisible.value);
+const syncNativeControls = () => {
+  nativeControlsVisible.value = !isLinux || controlsOverlay?.visible === true;
+};
+onMounted(() => {
+  syncNativeControls();
+  controlsOverlay?.addEventListener('geometrychange', syncNativeControls);
+});
+onUnmounted(() => controlsOverlay?.removeEventListener('geometrychange', syncNativeControls));
+const closeWindow = () => window.electron.windowControl('close');
 </script>
 
 <template>
@@ -34,6 +50,17 @@ const isMac = window.electron.platform === 'darwin';
       @click="toggleFullscreen"
     >
       <Icon :icon="iconFullscreen" width="14" height="14" />
+    </Button>
+    <Button
+      v-if="showFallbackClose"
+      variant="unstyled"
+      size="none"
+      class="window-action window-close-action"
+      tooltip="关闭窗口"
+      aria-label="关闭窗口"
+      @click="closeWindow"
+    >
+      <Icon :icon="iconX" width="16" height="16" />
     </Button>
   </div>
 </template>


### PR DESCRIPTION
## 变更内容

- 修复 Linux/Wayland 窗口控制区域短暂为空时，应用操作按钮覆盖原生关闭按钮的问题。
- 在原生标题栏控件不可见时提供 Linux 关闭按钮回退，并处理全屏与窗口背景切换后的安全区域刷新。

## 验证

- 相关 ESLint 检查通过。
- 窗口缩放与标题栏测试 7 项通过。