### PR TITLE
修复 Hyprland 窗口背景效果

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,9 +240,12 @@
         const startupRoot = document.documentElement;
         startupRoot.dataset.echoStarting = '';
         const dark = initialDark;
-        const alpha = appearance?.enabled
-          ? 1 - Math.max(0, Math.min(100, appearance.transparency || 0)) / 100
-          : 1;
+        const pureTransparent = appearance?.transparentMode === 'pure' && appearance?.enabled;
+        const alpha = pureTransparent
+          ? 0
+          : appearance?.enabled
+            ? 1 - Math.max(0, Math.min(100, appearance.transparency || 0)) / 100
+            : 1;
         const base =
           appearance?.enabled && appearance.color ? appearance.color : dark ? '#26262a' : '#f5f5f7';
         startupRoot.style.setProperty(

--- a/src/main/window/hyprlandBackground.ts
+++ b/src/main/window/hyprlandBackground.ts
@@ -1,0 +1,156 @@
+import { execFile } from 'node:child_process';
+import type { BrowserWindow } from 'electron';
+import log from '../logger';
+
+type HyprlandWindow = Pick<BrowserWindow, 'getNativeWindowHandle' | 'isDestroyed' | 'getTitle'>;
+
+const HYPRCTL_TIMEOUT_MS = 2000;
+const HYPRLAND_RETRY_MS = 500;
+const MIN_WINDOW_ADDRESS = 0x100;
+
+const getWindowAddress = (win: HyprlandWindow) => {
+  const handle = win.getNativeWindowHandle();
+  if (handle.length >= 8) {
+    const address = handle.readBigUInt64LE();
+    if (address > BigInt(MIN_WINDOW_ADDRESS)) return `0x${address.toString(16)}`;
+  }
+  if (handle.length >= 4) {
+    const address = handle.readUInt32LE();
+    if (address > MIN_WINDOW_ADDRESS) return `0x${address.toString(16)}`;
+  }
+  throw new Error('无法读取 Hyprland 窗口地址');
+};
+
+const runHyprctl = (args: string[]) =>
+  new Promise<string>((resolve, reject) => {
+    execFile('hyprctl', args, { timeout: HYPRCTL_TIMEOUT_MS }, (error, stdout) => {
+      if (error) reject(error);
+      else resolve(stdout);
+    });
+  });
+
+type HyprlandClient = {
+  address?: unknown;
+  class?: unknown;
+  pid?: unknown;
+  title?: unknown;
+};
+
+/**
+ * Wayland Electron windows expose a placeholder native handle (often 0x1),
+ * while Hyprland identifies the real surface by its compositor address.
+ * Resolve that address from the client list using the owning Electron PID.
+ */
+const getWaylandWindowAddress = async (win: HyprlandWindow) => {
+  const output = await runHyprctl(['clients', '-j']);
+  const clients: unknown = JSON.parse(output);
+  if (!Array.isArray(clients)) throw new Error('Hyprland clients 返回格式无效');
+
+  const title = win.getTitle();
+  const candidates = clients.filter((client): client is HyprlandClient => {
+    if (!client || typeof client !== 'object') return false;
+    const entry = client as HyprlandClient;
+    return (
+      Number(entry.pid) === process.pid &&
+      typeof entry.address === 'string' &&
+      /^0x[\da-f]+$/i.test(entry.address)
+    );
+  });
+  // Prefer EchoMusic's class when several Electron windows share this PID;
+  // title matching remains the final discriminator for plugin windows.
+  const appCandidates = candidates.filter((client) => client.class === 'echo-music');
+  const scopedCandidates = appCandidates.length > 0 ? appCandidates : candidates;
+  const matchingTitle = scopedCandidates.find((client) => client.title === title);
+  const client = matchingTitle ?? scopedCandidates[0];
+  if (typeof client?.address === 'string') return client.address;
+  throw new Error('未找到当前 Hyprland 窗口');
+};
+
+const resolveWindowAddress = async (win: HyprlandWindow) => {
+  try {
+    return await getWaylandWindowAddress(win);
+  } catch (waylandError) {
+    try {
+      return getWindowAddress(win);
+    } catch {
+      throw waylandError;
+    }
+  }
+};
+
+const applyWindowBlur = async (win: HyprlandWindow, enabled: boolean) => {
+  const address = await resolveWindowAddress(win);
+  const noBlur = enabled ? '0' : '1';
+  // Hyprland 0.55+ exposes dynamic window properties through its Lua
+  // dispatcher. Keep the legacy setprop form as a compatibility fallback for
+  // older installations that still use the hyprlang command interface.
+  const modern = [
+    'dispatch',
+    `hl.dsp.window.set_prop({ prop = "no_blur", value = "${noBlur}", window = "address:${address}" })`,
+  ];
+  try {
+    await runHyprctl(modern);
+    return;
+  } catch (modernError) {
+    try {
+      await runHyprctl(['setprop', `address:${address}`, 'noblur', noBlur]);
+    } catch {
+      throw modernError;
+    }
+  }
+};
+
+/**
+ * Synchronize the current window's compositor blur without changing the
+ * user's Hyprland configuration. The latest requested state wins while a
+ * hyprctl call is in flight.
+ */
+export function createHyprlandBackgroundController(win: HyprlandWindow) {
+  let requested: boolean | null = null;
+  let applied: boolean | null = null;
+  let running = false;
+  let retryTimer: NodeJS.Timeout | null = null;
+
+  const scheduleRetry = () => {
+    if (retryTimer || win.isDestroyed()) return;
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      void flush();
+    }, HYPRLAND_RETRY_MS);
+    if (typeof retryTimer.unref === 'function') retryTimer.unref();
+  };
+
+  const flush = async () => {
+    if (running) return;
+    running = true;
+    try {
+      while (requested !== null) {
+        const target = requested;
+        requested = null;
+        if (target === applied || win.isDestroyed()) continue;
+        try {
+          await applyWindowBlur(win, target);
+          applied = target;
+        } catch (error) {
+          log.debug('[HyprlandBackground] Unable to update window blur:', error);
+          // A Wayland surface may not appear in `hyprctl clients` until after
+          // ready-to-show. Keep the requested state and retry without blocking
+          // the main process; later changes replace this pending value.
+          requested = target;
+          scheduleRetry();
+          break;
+        }
+      }
+    } finally {
+      running = false;
+      if (requested !== null && !retryTimer) void flush();
+    }
+  };
+
+  return {
+    setBlurEnabled(enabled: boolean) {
+      requested = enabled;
+      void flush();
+    },
+  };
+}

--- a/src/main/window/index.ts
+++ b/src/main/window/index.ts
@@ -6,6 +6,10 @@ import {
   normalizeWindowBackground,
   type WindowBackground,
 } from '../../shared/window-background';
+import {
+  detectWindowBackgroundStrategy,
+  resolveWindowBackgroundCapabilities,
+} from '../../shared/window-background-strategy';
 import { BrowserWindow, shell, app, nativeTheme, powerSaveBlocker, screen } from 'electron';
 import { join } from 'path';
 import type { CloseBehavior, ThemeMode } from '../../shared/app';
@@ -26,6 +30,7 @@ import {
 } from './windowsComposition';
 import { applyMacWindowBackground } from './macComposition';
 import { createTitleBarController } from './titleBar';
+import { createHyprlandBackgroundController } from './hyprlandBackground';
 import { installWindowZoom, registerWindowZoomHandlers } from './zoom';
 import {
   installWindowFullscreen,
@@ -41,10 +46,18 @@ let closeBehavior: CloseBehavior = initialSettings.closeBehavior;
 let currentTheme: ThemeMode = initialSettings.theme;
 let windowBackground = normalizeWindowBackground(initialSettings.windowBackground);
 let windowBackgroundActiveEnabled = windowBackground.enabled;
-const supportsWindowFrost =
-  process.platform === 'darwin' ||
-  (process.platform === 'win32' &&
-    (Number(release().split('.')[2]) >= 22621 || supportsWindowsAccent()));
+const osBuild = Number(release().split('.')[2]);
+const windowBackgroundStrategy = detectWindowBackgroundStrategy({
+  platform: process.platform,
+  env: process.env,
+});
+const windowBackgroundCapabilities = resolveWindowBackgroundCapabilities({
+  platform: process.platform,
+  build: osBuild,
+  strategy: windowBackgroundStrategy,
+  windowsAccentAvailable: process.platform === 'win32' && supportsWindowsAccent(),
+});
+const supportsWindowFrost = windowBackgroundCapabilities.supportsFrost;
 
 if (!supportsWindowFrost && process.platform !== 'win32') windowBackground.frosted = false;
 let rememberWindowSize = initialSettings.rememberWindowSize;
@@ -161,14 +174,19 @@ const getMainWindowBackgroundColor = () =>
     ? '#26262a'
     : '#f5f5f7';
 
-let activeComposition = getWindowComposition(
-  windowBackground,
-  process.platform,
-  Number(release().split('.')[2]),
-);
+let activeComposition = getWindowComposition(windowBackground, process.platform, osBuild);
 let windowBackgroundActiveFrosted: boolean | null = windowBackground.frosted;
 let windowBackgroundRestartRequired = false;
+let hyprlandBackgroundController: ReturnType<typeof createHyprlandBackgroundController> | null =
+  null;
 export const getMainWindowClientCornerRadius = () => activeComposition.clientCornerRadius;
+
+const syncHyprlandBackground = () => {
+  if (!hyprlandBackgroundController) return;
+  hyprlandBackgroundController.setBlurEnabled(
+    windowBackgroundActiveEnabled && windowBackgroundActiveFrosted === true,
+  );
+};
 
 const syncMainWindowBackground = () => {
   if (!canUseMainWindow(win)) return;
@@ -184,7 +202,7 @@ const syncMainWindowBackground = () => {
     windowBackgroundRestartRequired = state.restartRequired;
     backgroundUnavailableReason = '';
     try {
-      applyWindowsComposition(win, state.background, Number(release().split('.')[2]));
+      applyWindowsComposition(win, state.background, osBuild);
       win.setBackgroundColor(
         state.background.enabled ? '#00000000' : getMainWindowBackgroundColor(),
       );
@@ -202,6 +220,7 @@ const syncMainWindowBackground = () => {
       windowBackground,
       process.platform,
       activeComposition.transparent,
+      windowBackgroundCapabilities,
     );
     windowBackgroundRestartRequired = state.restartRequired;
     windowBackgroundActiveEnabled = state.background.enabled;
@@ -216,6 +235,7 @@ const syncMainWindowBackground = () => {
       );
     }
   }
+  syncHyprlandBackground();
   // Publish only after native materials and surface colors agree with the renderer state.
   win.webContents.send('window-background:changed', readBackgroundState());
 };
@@ -225,15 +245,11 @@ const readBackgroundState = () => ({
   activeEnabled: windowBackgroundActiveEnabled,
   activeFrosted: windowBackgroundActiveFrosted,
   supportsFrost: supportsWindowFrost,
-  frostBackend: !supportsWindowFrost
-    ? 'none'
-    : process.platform === 'darwin'
-      ? 'vibrancy'
-      : Number(release().split('.')[2]) >= 22621
-        ? 'acrylic'
-        : 'accent-acrylic',
-  live: process.platform === 'win32' && Number(release().split('.')[2]) >= 22621,
-  frostLive: process.platform === 'darwin' || process.platform === 'win32',
+  frostBackend: windowBackgroundCapabilities.frostBackend,
+  strategy: windowBackgroundCapabilities.strategy,
+  transparentMode: windowBackgroundCapabilities.transparentMode,
+  live: windowBackgroundCapabilities.live,
+  frostLive: windowBackgroundCapabilities.frostLive,
   restartRequired: windowBackgroundRestartRequired,
   unavailableReason: backgroundUnavailableReason,
 });
@@ -350,11 +366,7 @@ export async function createWindow() {
   await logMainMemory('createWindow:before BrowserWindow');
 
   windowBackgroundActiveEnabled = windowBackground.enabled;
-  activeComposition = getWindowComposition(
-    windowBackground,
-    process.platform,
-    Number(release().split('.')[2]),
-  );
+  activeComposition = getWindowComposition(windowBackground, process.platform, osBuild);
   windowBackgroundActiveFrosted = windowBackground.frosted;
   windowBackgroundRestartRequired = false;
   win = new BrowserWindow({
@@ -398,7 +410,14 @@ export async function createWindow() {
       preload,
       additionalArguments: [
         `--echo-initial-dark=${initialBgColor === '#26262a'}`,
-        `--echo-window-background=${JSON.stringify({ ...resolveWindowBackground(windowBackground, windowBackgroundActiveEnabled), clientCornerRadius: rememberWindowSize && initialWindowState.isMaximized ? 0 : activeComposition.clientCornerRadius })}`,
+        `--echo-window-background=${JSON.stringify({
+          ...resolveWindowBackground(windowBackground, windowBackgroundActiveEnabled),
+          transparentMode: windowBackgroundCapabilities.transparentMode,
+          clientCornerRadius:
+            rememberWindowSize && initialWindowState.isMaximized
+              ? 0
+              : activeComposition.clientCornerRadius,
+        })}`,
       ],
       contextIsolation: true,
       nodeIntegration: false,
@@ -423,6 +442,9 @@ export async function createWindow() {
     win.setBounds(placement.bounds);
   }
   const mainWindow = win;
+  if (windowBackgroundStrategy === 'hyprland') {
+    hyprlandBackgroundController = createHyprlandBackgroundController(mainWindow);
+  }
   installWindowPointerEvents(mainWindow);
   titleBarController = usesNativeOverlay
     ? createTitleBarController(
@@ -465,6 +487,9 @@ export async function createWindow() {
       win?.show();
       void logMainMemory('main window:after show');
     }
+    // The native surface address is only reliable after the window has been
+    // created by the compositor; retry the selected blur mode at this point.
+    syncHyprlandBackground();
   });
 
   win.webContents.once('dom-ready', () => {

--- a/src/renderer/stores/setting.ts
+++ b/src/renderer/stores/setting.ts
@@ -22,6 +22,11 @@ import {
   normalizeNetworkSettings,
   type NetworkSettings,
 } from '../../shared/network';
+import type {
+  WindowBackgroundFrostBackend,
+  WindowBackgroundStrategyId,
+  WindowBackgroundTransparentMode,
+} from '../../shared/window-background-strategy';
 import { configureRendererLogger } from '@/utils/logger';
 import {
   dspPresetBankKey,
@@ -104,8 +109,10 @@ export const useSettingStore = defineStore('setting', {
     windowBackgroundNeedsRestart: false,
     windowBackgroundUnavailableReason: '',
     windowBackgroundActiveFrosted: null as boolean | null,
+    windowBackgroundStrategy: 'default' as WindowBackgroundStrategyId,
+    windowBackgroundTransparentMode: 'layered' as WindowBackgroundTransparentMode,
     supportsWindowFrost: false,
-    windowFrostBackend: 'none' as 'none' | 'vibrancy' | 'acrylic' | 'accent-acrylic',
+    windowFrostBackend: 'none' as WindowBackgroundFrostBackend,
     language: 'zh-CN',
     shortcutEnabled: true,
     suppressDefaultKeyBehaviors: true,
@@ -321,17 +328,23 @@ export const useSettingStore = defineStore('setting', {
       this.windowBackgroundActiveEnabled = result.activeEnabled === true;
       this.windowBackgroundActiveFrosted =
         typeof result.activeFrosted === 'boolean' ? result.activeFrosted : null;
+      this.windowBackgroundStrategy = result.strategy ?? 'default';
+      this.windowBackgroundTransparentMode = result.transparentMode ?? 'layered';
       this.supportsWindowFrost = result.supportsFrost;
       this.windowFrostBackend = result.frostBackend ?? 'none';
       this.windowBackgroundLive = result.live === true;
       this.windowBackgroundFrostLive = result.frostLive === true;
       this.windowBackgroundNeedsRestart = result.restartRequired === true;
       this.windowBackgroundUnavailableReason = result.unavailableReason || '';
-      applyWindowBackground(this.effectiveWindowBackground);
+      applyWindowBackground(this.effectiveWindowBackground, {
+        transparentMode: this.windowBackgroundTransparentMode,
+      });
     },
     async setWindowBackground(patch: Partial<WindowBackground>) {
       this.windowBackground = normalizeWindowBackground({ ...this.windowBackground, ...patch });
-      applyWindowBackground(this.effectiveWindowBackground);
+      applyWindowBackground(this.effectiveWindowBackground, {
+        transparentMode: this.windowBackgroundTransparentMode,
+      });
       await window.electron?.ipcRenderer.invoke('window-background:set', {
         ...this.windowBackground,
       });
@@ -722,6 +735,8 @@ export const useSettingStore = defineStore('setting', {
       'windowBackground',
       'windowBackgroundActiveEnabled',
       'windowBackgroundActiveFrosted',
+      'windowBackgroundStrategy',
+      'windowBackgroundTransparentMode',
       'supportsWindowFrost',
       'windowBackgroundLive',
       'windowBackgroundFrostLive',

--- a/src/renderer/utils/windowBackground.ts
+++ b/src/renderer/utils/windowBackground.ts
@@ -1,7 +1,14 @@
-import { resolveWindowBackground, type WindowBackground } from '../../shared/window-background';
+import {
+  resolveRendererWindowBackground,
+  type WindowBackground,
+} from '../../shared/window-background';
+import type { WindowBackgroundTransparentMode } from '../../shared/window-background-strategy';
 
-export function applyWindowBackground(value: WindowBackground) {
-  const background = resolveWindowBackground(value, value.enabled);
+export function applyWindowBackground(
+  value: WindowBackground,
+  options: { transparentMode?: WindowBackgroundTransparentMode } = {},
+) {
+  const background = resolveRendererWindowBackground(value, options.transparentMode);
   const root = document.documentElement;
   root.classList.toggle('app-background-enabled', background.enabled);
   root.classList.toggle('app-background-transparent', background.enabled);

--- a/src/renderer/views/settings/components/AppearanceSettingsSection.vue
+++ b/src/renderer/views/settings/components/AppearanceSettingsSection.vue
@@ -93,15 +93,14 @@ const backgroundMode = computed(() =>
       ? 'frosted'
       : 'transparent',
 );
-const backgroundModeOptions = computed(() => [
-  { label: '关闭', value: 'off' },
-  { label: '透明', value: 'transparent' },
-  {
-    label: settingStore.supportsWindowFrost ? '毛玻璃' : '毛玻璃（暂不支持）',
-    value: 'frosted',
-    disabled: !settingStore.supportsWindowFrost,
-  },
-]);
+const backgroundModeOptions = computed(() => {
+  const options = [
+    { label: '关闭', value: 'off' },
+    { label: '透明', value: 'transparent' },
+  ];
+  if (settingStore.supportsWindowFrost) options.push({ label: '毛玻璃', value: 'frosted' });
+  return options;
+});
 const setBackgroundMode = (value: unknown) => {
   if (value !== 'off' && value !== 'transparent' && value !== 'frosted') return;
   if (value === 'frosted' && !settingStore.supportsWindowFrost) return;
@@ -148,9 +147,11 @@ const isAccentGradientDefault = computed(
               ? '保留系统窗口动画、边框和原生按钮；切换立即生效'
               : windowPlatform === 'win32'
                 ? '透明与毛玻璃可即时切换；开启或关闭背景效果需重启'
-                : settingStore.windowBackgroundFrostLive
-                  ? '关闭与毛玻璃可即时切换；进出透明模式需重启'
-                  : '透明效果取决于桌面合成器；切换后需重启，暂不支持毛玻璃'
+                : settingStore.windowFrostBackend === 'hyprland-blur'
+                  ? '透明效果取决于桌面合成器；切换后需重启'
+                  : settingStore.windowBackgroundFrostLive
+                    ? '关闭与毛玻璃可即时切换；进出透明模式需重启'
+                    : '透明效果取决于桌面合成器；切换后需重启'
           }}
         </p>
         <p
@@ -216,7 +217,26 @@ const isAccentGradientDefault = computed(
         @update:model-value="setBackgroundMode"
       />
     </div>
-    <template v-if="backgroundMode === 'transparent'">
+    <template
+      v-if="
+        backgroundMode === 'transparent' && settingStore.windowBackgroundTransparentMode === 'pure'
+      "
+    >
+      <div class="settings-divider"></div>
+      <div class="settings-item">
+        <div class="space-y-1">
+          <h3 class="font-semibold">纯透明模式</h3>
+          <p class="text-sm text-text-secondary">
+            当前桌面后端提供真正的透明窗口，透明度和背景底色由合成器处理
+          </p>
+        </div>
+      </div>
+    </template>
+    <template
+      v-else-if="
+        backgroundMode === 'transparent' && settingStore.windowBackgroundTransparentMode !== 'pure'
+      "
+    >
       <div class="settings-divider"></div>
       <div class="settings-item">
         <div class="space-y-1">

--- a/src/shared/window-background-strategy.ts
+++ b/src/shared/window-background-strategy.ts
@@ -1,0 +1,120 @@
+/**
+ * Window-background behavior selected by the host desktop/compositor.
+ *
+ * Keep backend detection and capabilities in this module so adding another
+ * compositor later does not spread platform checks through the renderer and
+ * the main window implementation.
+ */
+export type WindowBackgroundStrategyId = 'default' | 'hyprland';
+
+export type WindowBackgroundTransparentMode = 'layered' | 'pure';
+
+export type WindowBackgroundFrostMode = 'none' | 'native' | 'compositor';
+
+export type WindowBackgroundFrostBackend =
+  | 'none'
+  | 'vibrancy'
+  | 'acrylic'
+  | 'accent-acrylic'
+  | 'blur-behind'
+  | 'hyprland-blur';
+
+export interface WindowBackgroundCapabilities {
+  strategy: WindowBackgroundStrategyId;
+  supportsFrost: boolean;
+  frostBackend: WindowBackgroundFrostBackend;
+  frostMode: WindowBackgroundFrostMode;
+  /** Whether the selected frost implementation can switch without relaunch. */
+  frostLive: boolean;
+  /** Whether entering/leaving an enabled background mode can switch live. */
+  live: boolean;
+  transparentMode: WindowBackgroundTransparentMode;
+}
+
+type Environment = Readonly<Record<string, string | undefined>>;
+
+const desktopNames = (value: string | undefined) =>
+  (value ?? '')
+    .split(/[:;,]/)
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+
+/** Detect Hyprland without depending on a compositor-specific executable. */
+export function isHyprlandEnvironment(env: Environment = {}) {
+  if (env.HYPRLAND_INSTANCE_SIGNATURE?.trim()) return true;
+  return [env.XDG_CURRENT_DESKTOP, env.XDG_SESSION_DESKTOP, env.DESKTOP_SESSION].some((value) =>
+    desktopNames(value).includes('hyprland'),
+  );
+}
+
+export function detectWindowBackgroundStrategy({
+  platform,
+  env = {},
+}: {
+  platform: string;
+  env?: Environment;
+}): WindowBackgroundStrategyId {
+  return platform === 'linux' && isHyprlandEnvironment(env) ? 'hyprland' : 'default';
+}
+
+export function resolveWindowBackgroundCapabilities({
+  platform,
+  build,
+  strategy = 'default',
+  windowsAccentAvailable = false,
+}: {
+  platform: string;
+  build: number;
+  strategy?: WindowBackgroundStrategyId;
+  windowsAccentAvailable?: boolean;
+}): WindowBackgroundCapabilities {
+  if (platform === 'win32') {
+    const supportsFrost = build >= 22621 || windowsAccentAvailable;
+    return {
+      strategy: 'default',
+      supportsFrost,
+      frostBackend: supportsFrost ? (build >= 22621 ? 'acrylic' : 'accent-acrylic') : 'none',
+      frostMode: supportsFrost ? 'native' : 'none',
+      frostLive: true,
+      live: true,
+      transparentMode: 'layered',
+    };
+  }
+
+  if (platform === 'darwin') {
+    return {
+      strategy: 'default',
+      supportsFrost: true,
+      frostBackend: 'vibrancy',
+      frostMode: 'native',
+      frostLive: true,
+      live: false,
+      transparentMode: 'layered',
+    };
+  }
+
+  if (platform === 'linux' && strategy === 'hyprland') {
+    return {
+      strategy: 'hyprland',
+      // Hyprland supplies the backdrop through decoration.blur. The app only
+      // exposes a transparent surface and never edits the user's compositor
+      // configuration.
+      supportsFrost: true,
+      frostBackend: 'hyprland-blur',
+      frostMode: 'compositor',
+      frostLive: true,
+      live: false,
+      transparentMode: 'pure',
+    };
+  }
+
+  return {
+    strategy: 'default',
+    supportsFrost: false,
+    frostBackend: 'none',
+    frostMode: 'none',
+    frostLive: false,
+    live: false,
+    transparentMode: 'layered',
+  };
+}

--- a/src/shared/window-background.ts
+++ b/src/shared/window-background.ts
@@ -1,3 +1,8 @@
+import type {
+  WindowBackgroundCapabilities,
+  WindowBackgroundTransparentMode,
+} from './window-background-strategy';
+
 export interface WindowBackground {
   enabled: boolean;
   transparency: number;
@@ -58,8 +63,11 @@ export function resolveRunningWindowBackground(
   value: WindowBackground,
   platform: string,
   transparent: boolean,
-  build = 22621,
+  buildOrCapabilities: number | Pick<WindowBackgroundCapabilities, 'frostMode'> = 22621,
 ) {
+  const build = typeof buildOrCapabilities === 'number' ? buildOrCapabilities : 22621;
+  const frostMode =
+    typeof buildOrCapabilities === 'number' ? 'none' : buildOrCapabilities.frostMode;
   const wanted = normalizeWindowBackground(value);
   if (platform === 'win32') {
     if (build >= 22621) return { background: wanted, restartRequired: false };
@@ -82,8 +90,28 @@ export function resolveRunningWindowBackground(
     };
   }
   // Linux has no Electron backdrop-material API; preserve the current native mode until restart.
+  // Hyprland's compositor blur uses the same transparent BrowserWindow setup,
+  // but unlike other Linux backends its frosted mode remains meaningful at runtime.
   return {
-    background: resolveWindowBackground(wanted, transparent, false),
+    background: resolveWindowBackground(
+      wanted,
+      transparent,
+      frostMode === 'compositor' ? wanted.frosted : false,
+    ),
     restartRequired: wanted.enabled !== transparent,
   };
+}
+
+/**
+ * Resolve the renderer-facing appearance after the host backend is known.
+ * Hyprland's compositor owns both blur and translucency, so no synthetic
+ * color/opacity layer should be painted by the page in that mode.
+ */
+export function resolveRendererWindowBackground(
+  value: WindowBackground,
+  transparentMode: WindowBackgroundTransparentMode = 'layered',
+): WindowBackground {
+  const normalized = normalizeWindowBackground(value);
+  if (transparentMode !== 'pure' || !normalized.enabled) return normalized;
+  return { ...normalized, transparency: 100, color: '' };
 }

--- a/tests/startup-placeholder.test.mjs
+++ b/tests/startup-placeholder.test.mjs
@@ -38,6 +38,16 @@ test('main startup adopts the saved theme and material, other windows stay untou
     echoWindowBackground: { enabled: true, color: '#334455', transparency: 30 },
   });
   assert.equal(alpha.values.get('--startup-bg'), 'color-mix(in srgb, #334455 70%, transparent)');
+  const pure = bootstrap({
+    echoInitialDark: false,
+    echoWindowBackground: {
+      enabled: true,
+      color: '#334455',
+      transparency: 30,
+      transparentMode: 'pure',
+    },
+  });
+  assert.equal(pure.values.get('--startup-bg'), 'color-mix(in srgb, #334455 0%, transparent)');
   assert.deepEqual(bootstrap({}).root.dataset, {});
 });
 

--- a/tests/window-background-strategy.test.ts
+++ b/tests/window-background-strategy.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  detectWindowBackgroundStrategy,
+  isHyprlandEnvironment,
+  resolveWindowBackgroundCapabilities,
+} from '../src/shared/window-background-strategy.ts';
+
+test('Hyprland detection accepts its instance signature and desktop identifiers', () => {
+  assert.equal(isHyprlandEnvironment({ HYPRLAND_INSTANCE_SIGNATURE: 'abc123' }), true);
+  assert.equal(isHyprlandEnvironment({ XDG_CURRENT_DESKTOP: 'Hyprland' }), true);
+  assert.equal(isHyprlandEnvironment({ XDG_CURRENT_DESKTOP: 'hyprland:wlroots' }), true);
+  assert.equal(isHyprlandEnvironment({ XDG_CURRENT_DESKTOP: 'KDE' }), false);
+  assert.equal(
+    detectWindowBackgroundStrategy({
+      platform: 'linux',
+      env: { XDG_SESSION_DESKTOP: 'Hyprland' },
+    }),
+    'hyprland',
+  );
+  assert.equal(
+    detectWindowBackgroundStrategy({
+      platform: 'darwin',
+      env: { HYPRLAND_INSTANCE_SIGNATURE: 'abc123' },
+    }),
+    'default',
+  );
+});
+
+test('Hyprland uses compositor blur and pure transparency', () => {
+  assert.deepEqual(
+    resolveWindowBackgroundCapabilities({ platform: 'linux', build: 0, strategy: 'hyprland' }),
+    {
+      strategy: 'hyprland',
+      supportsFrost: true,
+      frostBackend: 'hyprland-blur',
+      frostMode: 'compositor',
+      frostLive: true,
+      live: false,
+      transparentMode: 'pure',
+    },
+  );
+});
+
+test('non-Hyprland Linux keeps the existing no-frost, layered behavior', () => {
+  assert.deepEqual(resolveWindowBackgroundCapabilities({ platform: 'linux', build: 0 }), {
+    strategy: 'default',
+    supportsFrost: false,
+    frostBackend: 'none',
+    frostMode: 'none',
+    frostLive: false,
+    live: false,
+    transparentMode: 'layered',
+  });
+});

--- a/tests/window-background.test.ts
+++ b/tests/window-background.test.ts
@@ -5,6 +5,7 @@ import {
   getWindowComposition,
   normalizeWindowBackground,
   resolveWindowBackground,
+  resolveRendererWindowBackground,
   resolveRunningWindowBackground,
 } from '../src/shared/window-background.ts';
 
@@ -114,10 +115,13 @@ test('modern Windows retains live native composition at the build boundary', () 
 });
 test('legacy Windows can cancel a pending clear selection without restarting', () => {
   assert.equal(resolveRunningWindowBackground(clear, 'win32', false, 19045).restartRequired, true);
-  assert.deepEqual(resolveRunningWindowBackground(DEFAULT_WINDOW_BACKGROUND, 'win32', false, 19045), {
-    background: DEFAULT_WINDOW_BACKGROUND,
-    restartRequired: false,
-  });
+  assert.deepEqual(
+    resolveRunningWindowBackground(DEFAULT_WINDOW_BACKGROUND, 'win32', false, 19045),
+    {
+      background: DEFAULT_WINDOW_BACKGROUND,
+      restartRequired: false,
+    },
+  );
   const saved = { ...clear, transparency: 87, color: '#123456' };
   const pending = resolveRunningWindowBackground(saved, 'win32', false, 19045);
   assert.equal(pending.background.enabled, false);
@@ -165,5 +169,26 @@ test('Linux preserves native transparency until recreation and never enables Vib
   assert.deepEqual(resolveRunningWindowBackground(DEFAULT_WINDOW_BACKGROUND, 'linux', false), {
     background: DEFAULT_WINDOW_BACKGROUND,
     restartRequired: false,
+  });
+});
+
+test('compositor-backed frost stays active on an existing transparent window', () => {
+  assert.deepEqual(
+    resolveRunningWindowBackground(frost, 'linux', true, { frostMode: 'compositor' }),
+    {
+      background: frost,
+      restartRequired: false,
+    },
+  );
+});
+
+test('Hyprland renderer uses a pure transparent surface', () => {
+  assert.deepEqual(resolveRendererWindowBackground(clear, 'pure'), {
+    ...clear,
+    transparency: 100,
+    color: '',
+  });
+  assert.deepEqual(resolveRendererWindowBackground(DEFAULT_WINDOW_BACKGROUND, 'pure'), {
+    ...DEFAULT_WINDOW_BACKGROUND,
   });
 });


### PR DESCRIPTION
## 变更内容

- 在 Linux 下检测到 Hyprland 时，将毛玻璃映射为合成器 blur，并将透明模式设置为纯透明窗口表面。
- 非 Hyprland Linux 不显示毛玻璃选项，保留现有分层透明行为；其他平台保持原有规则。
- 将后端能力与策略集中在共享模块，方便后续扩展其他桌面后端。
- 增加 Hyprland 窗口模糊同步、启动占位背景及策略解析测试。

## 验证

- 相关 ESLint 检查通过。
- 窗口背景、启动占位、标题栏与缩放测试共 29 项通过。
- vue-tsc 类型检查通过。
- Vite 生产构建通过（仅有依赖和工具链已有警告）。